### PR TITLE
set executionSchema on config init

### DIFF
--- a/config.go
+++ b/config.go
@@ -237,6 +237,8 @@ func (c *Config) Init() error {
 		return err
 	}
 
+	c.executableSchema = es
+
 	var pluginsNames []string
 	for _, plugin := range c.plugins {
 		plugin.Init(c.executableSchema)


### PR DESCRIPTION
executionSchema was not being set on the config object and causing a nil pointer dereference

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x15394fb]
goroutine 52 [running]:
github.com/movio/bramble.(*ExecutableSchema).UpdateSchema(0x0, 0xc000051700, 0x0, 0x0)
	/Users/lucianj/code/bramble/execution.go:75 +0x9b
github.com/movio/bramble.(*Gateway).UpdateSchemas(0xc00027f0c0, 0x12a05f200)
	/Users/lucianj/code/bramble/gateway.go:27 +0x97
created by github.com/movio/bramble.Main
	/Users/lucianj/code/bramble/main.go:38 +0x470
```