### PR TITLE
Schema validation and merge fixes

### DIFF
--- a/format.go
+++ b/format.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/vektah/gqlparser/v2/ast"
+	"github.com/vektah/gqlparser/v2/formatter"
 )
 
 func indentPrefix(sb *strings.Builder, level int, suffix ...string) (int, error) {
@@ -352,4 +353,11 @@ func getInnerTypeName(t *ast.Type) string {
 	}
 
 	return t.Name()
+}
+
+func formatSchema(schema *ast.Schema) string {
+	buf := bytes.NewBufferString("")
+	f := formatter.NewFormatter(buf)
+	f.FormatSchema(schema)
+	return buf.String()
 }

--- a/merge.go
+++ b/merge.go
@@ -11,8 +11,22 @@ func MergeSchemas(schemas ...*ast.Schema) (*ast.Schema, error) {
 		return nil, fmt.Errorf("no source schemas")
 	}
 	if len(schemas) == 1 {
-		return schemas[0], nil
+		// if we have only one schema we append a minimal schema so that we can
+		// still go through the merging logic and prune special types (e.g.
+		// Service)
+		schemas = append(schemas, gqlparser.MustLoadSchema(&ast.Source{Name: "empty schema", Input: `
+		type Service {
+			name: String!
+			version: String!
+			schema: String!
 	}
+
+		type Query {
+			service: Service!
+		}
+		`}))
+	}
+
 	merged := ast.Schema{
 		Types:         make(map[string]*ast.Definition),
 		Directives:    make(map[string]*ast.DirectiveDefinition),

--- a/merge_fixtures_test.go
+++ b/merge_fixtures_test.go
@@ -1,13 +1,11 @@
 package bramble
 
 import (
-	"bytes"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/vektah/gqlparser/v2"
 	"github.com/vektah/gqlparser/v2/ast"
-	"github.com/vektah/gqlparser/v2/formatter"
 )
 
 type MergeTestFixture struct {
@@ -74,13 +72,6 @@ func (f BuildFieldURLMapFixture) Check(t *testing.T) {
 
 func loadSchema(input string) *ast.Schema {
 	return gqlparser.MustLoadSchema(&ast.Source{Name: "schema", Input: input})
-}
-
-func formatSchema(schema *ast.Schema) string {
-	buf := bytes.NewBufferString("")
-	f := formatter.NewFormatter(buf)
-	f.FormatSchema(schema)
-	return buf.String()
 }
 
 func loadAndFormatSchema(input string) string {

--- a/merge_test.go
+++ b/merge_test.go
@@ -774,3 +774,43 @@ func TestMergeCustomnScalars(t *testing.T) {
 	}
 	fixture.CheckSuccess(t)
 }
+
+func TestMergeEmptyQuery(t *testing.T) {
+	fixture := MergeTestFixture{
+		Input1: `
+			type Service {
+				name: String!
+				version: String!
+				schema: String!
+			}
+
+            type Query {
+				service: Service!
+            }
+
+			type Mutation {
+				addGizmo(name: String!): ID!
+			}
+		`,
+		Input2: `
+			type Service {
+				name: String!
+				version: String!
+				schema: String!
+			}
+
+            type Query {
+				service: Service!
+            }
+
+			type Mutation {
+				updateGizmo(name: String!): ID!
+			}
+		`,
+		Expected: `type Mutation {
+			updateGizmo(name: String!): ID!
+			addGizmo(name: String!): ID!
+		}`,
+	}
+	fixture.CheckSuccess(t)
+}

--- a/merge_test.go
+++ b/merge_test.go
@@ -9,6 +9,12 @@ import (
 func TestMergeSingleSchema(t *testing.T) {
 	fixture := MergeTestFixture{
 		Input1: `
+			type Service {
+				name: String!
+				version: String!
+				schema: String!
+			}
+
 			interface Named {
 				name: String!
 			}
@@ -20,6 +26,7 @@ func TestMergeSingleSchema(t *testing.T) {
 
 			type Query {
 				gizmo(id: ID!): Gizmo!
+				service: Service!
 			}
 		`,
 		Expected: `

--- a/validate_test.go
+++ b/validate_test.go
@@ -705,3 +705,39 @@ func TestRootObjectNaming(t *testing.T) {
 		}`).assertInvalid("the schema Subscription type can not be renamed to SubObj", validateRootObjectNames)
 	})
 }
+
+func TestSchemaValidAfterMerge(t *testing.T) {
+	t.Run("invalid use of Servive type", func(t *testing.T) {
+		withSchema(t, `
+		type Service {
+			name: String!
+			version: String!
+			schema: String!
+		}
+
+		type Query {
+			service: Service!
+		}
+
+		type Mutation {
+			service: Service!
+		}`).assertInvalid("schema will become invalid after merge operation: merged schema:3: Undefined type Service.", validateSchemaValidAfterMerge)
+	})
+
+	t.Run("valid schema with empty Query type", func(t *testing.T) {
+		withSchema(t, `
+		type Service {
+			name: String!
+			version: String!
+			schema: String!
+		}
+
+		type Query {
+			service: Service!
+		}
+
+		type Mutation {
+			a: String!
+		}`).assertValid(validateSchemaValidAfterMerge)
+	})
+}


### PR DESCRIPTION
- Go through the merging logic even when merging a single schema: even when using a single schema we need to go through the merging logic to avoid exposing the underlying special types and queries (Service and
node).

- Removed empty `Query` type from merged schema. If the schemas contain only the `service: Service!` query it means the resulting `Query` type will be empty and should thus be removed from the result.

- Check schema is still going to be valid after merge, i.e. after we've removed the special types from the schema.