### PR TITLE
Fix schema introspection

### DIFF
--- a/execution_test.go
+++ b/execution_test.go
@@ -54,8 +54,12 @@ func TestIntrospectionQuery(t *testing.T) {
 		somethingRandom: MovieOrCinema
 	}`
 
+	// Make sure schema merging doesn't break introspection
+	mergedSchema, err := MergeSchemas(gqlparser.MustLoadSchema(&ast.Source{Name: "fixture", Input: schema}))
+	require.NoError(t, err)
+
 	es := ExecutableSchema{
-		MergedSchema: gqlparser.MustLoadSchema(&ast.Source{Name: "fixture", Input: schema}),
+		MergedSchema: mergedSchema,
 	}
 
 	t.Run("basic type fields", func(t *testing.T) {

--- a/merge.go
+++ b/merge.go
@@ -155,10 +155,6 @@ func mergeTypes(a, b map[string]*ast.Definition) (map[string]*ast.Definition, er
 			if err != nil {
 				return nil, err
 			}
-			if len(mergedObject.Fields) == 0 {
-				delete(result, k)
-				continue
-			}
 			result[k] = mergedObject
 			continue
 		}
@@ -233,7 +229,7 @@ func mergePossibleTypes(sources []*ast.Schema, mergedTypes map[string]*ast.Defin
 func mergeNamespaceObjects(aTypes, bTypes map[string]*ast.Definition, a, b *ast.Definition) (*ast.Definition, error) {
 	var fields ast.FieldList
 	for _, f := range a.Fields {
-		if isQueryType(a) && (isNodeField(f) || isServiceField(f) || isGraphQLBuiltinName(f.Name)) {
+		if isQueryType(a) && (isNodeField(f) || isServiceField(f)) {
 			continue
 		}
 		fields = append(fields, f)
@@ -410,4 +406,15 @@ func isNamespaceObject(a *ast.Definition) bool {
 
 func hasFederationDirectives(o *ast.Definition) bool {
 	return isBoundaryObject(o) || isNamespaceObject(o)
+}
+
+func filterBuiltinFields(fields ast.FieldList) ast.FieldList {
+	var res ast.FieldList
+	for _, f := range fields {
+		if isGraphQLBuiltinName(f.Name) {
+			continue
+		}
+		res = append(res, f)
+	}
+	return res
 }

--- a/merge_fixtures_test.go
+++ b/merge_fixtures_test.go
@@ -33,6 +33,14 @@ func (f MergeTestFixture) CheckSuccess(t *testing.T) {
 		schemas = append(schemas, loadSchema(f.Input2))
 	}
 	actual := mustMergeSchemas(t, schemas...)
+
+	// If resulting Query type is empty, remove it from schema to avoid
+	// generating an invalid schema when formatting (empty Query type: `type Query {}`)
+	if actual.Query != nil && len(filterBuiltinFields(actual.Query.Fields)) == 0 {
+		delete(actual.Types, "Query")
+		delete(actual.PossibleTypes, "Query")
+	}
+
 	assertSchemaConsistency(t, actual)
 	assert.Equal(t, loadAndFormatSchema(f.Expected), formatSchema(actual))
 }

--- a/validate.go
+++ b/validate.go
@@ -365,6 +365,12 @@ func validateSchemaValidAfterMerge(schema *ast.Schema) error {
 		return fmt.Errorf("merge schema error: %w", err)
 	}
 
+	// If resulting Query type is empty, remove it from schema to avoid
+	// generating an invalid schema when formatting (empty Query type: `type Query {}`)
+	if len(filterBuiltinFields(mergedSchema.Query.Fields)) == 0 {
+		delete(mergedSchema.Types, "Query")
+	}
+
 	// format and reload the schema to ensure it is valid
 	res := formatSchema(mergedSchema)
 	_, gqlErr := gqlparser.LoadSchema(&ast.Source{Name: "merged schema", Input: res})


### PR DESCRIPTION
The idea with https://github.com/movio/bramble/pull/5 was to remove the `Query` type from the merged schema if it doesn't contain any non builtin type.

The reason for doing that was that having an empty `Query` type would generate an invalid schema when formatting using `gqlparser`. However, now the issue is that it broke introspection...

So went another route instead and chose to delete the `Query` type from the schema only in the (very) few places where we need to format the schema with an empty query type.