### PR TITLE
Add support for `__typename` fields on namespace objects

### DIFF
--- a/plan_test.go
+++ b/plan_test.go
@@ -203,6 +203,13 @@ func TestQueryPlanWithTypename(t *testing.T) {
 				"SelectionSet": "{ transactions { id gross __typename } }",
 				"InsertionPoint": null,
 				"Then": null
+			  },
+			  {
+				"ServiceURL": "__bramble",
+				"ParentType": "Query",
+				"SelectionSet": "{ __typename }",
+				"InsertionPoint": null,
+				"Then": null
 			  }
 			]
 		  }

--- a/schema.go
+++ b/schema.go
@@ -18,6 +18,8 @@ const (
 	queryObjectName        = "Query"
 	mutationObjectName     = "Mutation"
 	subscriptionObjectName = "Subscription"
+
+	internalServiceName = "__bramble"
 )
 
 func isGraphQLBuiltinName(s string) bool {


### PR DESCRIPTION
This adds support for `__typename` fields on namespace objects, e.g.:
```graphql
{
  myNamespace {
    __typename
  }
}
```
As these fields are quite special (they are not attached to a specific service) and we are not guaranteed to actually query a single service (see above example), I added some new logic for "bramble only" fields.

So:
- In the planning: allocate these fields to a special `__bramble` service
- In the execution: use `executeBrambleStep` to execute that special step