### PR TITLE
Configure GQLClient max-response-size

### DIFF
--- a/client.go
+++ b/client.go
@@ -21,12 +21,12 @@ type GraphQLClient struct {
 	Tracer          opentracing.Tracer
 }
 
-func NewClient() *GraphQLClient {
+func NewClient(maxResponseSize int64) *GraphQLClient {
 	return &GraphQLClient{
 		HTTPClient: &http.Client{
 			Timeout: 5 * time.Second,
 		},
-		MaxResponseSize: 1024 * 1024,
+		MaxResponseSize: maxResponseSize,
 	}
 }
 

--- a/client.go
+++ b/client.go
@@ -21,12 +21,26 @@ type GraphQLClient struct {
 	Tracer          opentracing.Tracer
 }
 
-func NewClient(maxResponseSize int64) *GraphQLClient {
-	return &GraphQLClient{
+type ClientOpt func(*GraphQLClient)
+
+func NewClient(opts ...ClientOpt) *GraphQLClient {
+	c := &GraphQLClient{
 		HTTPClient: &http.Client{
 			Timeout: 5 * time.Second,
 		},
-		MaxResponseSize: maxResponseSize,
+		MaxResponseSize: 1024 * 1024,
+	}
+
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	return c
+}
+
+func WithMaxResponseSize(maxResponseSize int64) ClientOpt {
+	return func(s *GraphQLClient) {
+		s.MaxResponseSize = maxResponseSize
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -233,7 +233,7 @@ func (c *Config) Init() error {
 		services = append(services, NewService(s))
 	}
 
-	client := NewClient(WithMaxResponseSize(c.MaxRequestsPerQuery))
+	client := NewClient(WithMaxResponseSize(c.MaxServiceResponseSize))
 	es := newExecutableSchema(c.plugins, c.MaxRequestsPerQuery, client, services...)
 	err = es.UpdateSchema(true)
 	if err != nil {

--- a/config.go
+++ b/config.go
@@ -19,16 +19,16 @@ type PluginConfig struct {
 
 // Config contains the gateway configuration
 type Config struct {
-	GatewayPort          int       `json:"gateway-port"`
-	MetricsPort          int       `json:"metrics-port"`
-	PrivatePort          int       `json:"private-port"`
-	Services             []string  `json:"services"`
-	LogLevel             log.Level `json:"loglevel"`
-	PollInterval         string    `json:"poll-interval"`
-	PollIntervalDuration time.Duration
-	MaxRequestsPerQuery  int64 `json:"max-requests-per-query"`
-	MaxResponseSize      int64 `json:"max-service-response-size"`
-	Plugins              []PluginConfig
+	GatewayPort            int       `json:"gateway-port"`
+	MetricsPort            int       `json:"metrics-port"`
+	PrivatePort            int       `json:"private-port"`
+	Services               []string  `json:"services"`
+	LogLevel               log.Level `json:"loglevel"`
+	PollInterval           string    `json:"poll-interval"`
+	PollIntervalDuration   time.Duration
+	MaxRequestsPerQuery    int64 `json:"max-requests-per-query"`
+	MaxServiceResponseSize int64 `json:"max-service-response-size"`
+	Plugins                []PluginConfig
 	// Config extensions that can be shared among plugins
 	Extensions map[string]json.RawMessage
 
@@ -186,13 +186,13 @@ func GetConfig(configFiles []string) (*Config, error) {
 	}
 
 	cfg := Config{
-		GatewayPort:         8082,
-		PrivatePort:         8083,
-		MetricsPort:         9009,
-		LogLevel:            log.DebugLevel,
-		PollInterval:        "5s",
-		MaxRequestsPerQuery: 50,
-		MaxResponseSize:     1024 * 1024,
+		GatewayPort:            8082,
+		PrivatePort:            8083,
+		MetricsPort:            9009,
+		LogLevel:               log.DebugLevel,
+		PollInterval:           "5s",
+		MaxRequestsPerQuery:    50,
+		MaxServiceResponseSize: 1024 * 1024,
 
 		watcher:     watcher,
 		configFiles: configFiles,

--- a/config.go
+++ b/config.go
@@ -27,7 +27,7 @@ type Config struct {
 	PollInterval         string    `json:"poll-interval"`
 	PollIntervalDuration time.Duration
 	MaxRequestsPerQuery  int64 `json:"max-requests-per-query"`
-	MaxResponseSize      int64 `json:"max-client-response-size"`
+	MaxResponseSize      int64 `json:"max-service-response-size"`
 	Plugins              []PluginConfig
 	// Config extensions that can be shared among plugins
 	Extensions map[string]json.RawMessage
@@ -233,7 +233,8 @@ func (c *Config) Init() error {
 		services = append(services, NewService(s))
 	}
 
-	es := newExecutableSchema(c.plugins, c.MaxRequestsPerQuery, c.MaxResponseSize, services...)
+	client := NewClient(WithMaxResponseSize(c.MaxRequestsPerQuery))
+	es := newExecutableSchema(c.plugins, c.MaxRequestsPerQuery, client, services...)
 	err = es.UpdateSchema(true)
 	if err != nil {
 		return err

--- a/config.go
+++ b/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	PollInterval         string    `json:"poll-interval"`
 	PollIntervalDuration time.Duration
 	MaxRequestsPerQuery  int64 `json:"max-requests-per-query"`
+	MaxResponseSize      int64 `json:"max-client-response-size"`
 	Plugins              []PluginConfig
 	// Config extensions that can be shared among plugins
 	Extensions map[string]json.RawMessage
@@ -191,6 +192,7 @@ func GetConfig(configFiles []string) (*Config, error) {
 		LogLevel:            log.DebugLevel,
 		PollInterval:        "5s",
 		MaxRequestsPerQuery: 50,
+		MaxResponseSize:     1024 * 1024,
 
 		watcher:     watcher,
 		configFiles: configFiles,
@@ -231,7 +233,7 @@ func (c *Config) Init() error {
 		services = append(services, NewService(s))
 	}
 
-	es := newExecutableSchema(c.plugins, c.MaxRequestsPerQuery, services...)
+	es := newExecutableSchema(c.plugins, c.MaxRequestsPerQuery, c.MaxResponseSize, services...)
 	err = es.UpdateSchema(true)
 	if err != nil {
 		return err

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,7 +15,7 @@ Sample configuration:
   "log-level": "info",
   "poll-interval": "5s",
   "max-requests-per-query": 50,
-  "max-client-response-size": ...
+  "max-client-response-size": 1048576,
   "plugins": [
     {
       "name": "admin-ui"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -72,7 +72,7 @@ Sample configuration:
   - Default: 50
   - Supports hot-reload: No
 
-- `max-client-response-size`: The max response size you can receive from the gateway
+- `max-service-response-size`: The max response size that Bramble can receive from federated services
   - Default: 1MB
   - Supports hot-reload: No
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,6 +15,7 @@ Sample configuration:
   "log-level": "info",
   "poll-interval": "5s",
   "max-requests-per-query": 50,
+  "max-client-response-size": ...
   "plugins": [
     {
       "name": "admin-ui"
@@ -69,6 +70,10 @@ Sample configuration:
   federated services.
 
   - Default: 50
+  - Supports hot-reload: No
+
+- `max-client-response-size`: The max response size you can receive from the gateway
+  - Default: 1MB
   - Supports hot-reload: No
 
 - `plugins`: Optional list of plugins to enable. See [plugins](plugins.md) for plugins-specific config.

--- a/execution.go
+++ b/execution.go
@@ -19,11 +19,15 @@ import (
 	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
-func newExecutableSchema(plugins []Plugin, maxRequestsPerQuery, maxResponseSize int64, services ...*Service) *ExecutableSchema {
-	client := NewClient(maxResponseSize)
+func newExecutableSchema(plugins []Plugin, maxRequestsPerQuery int64, client *GraphQLClient, services ...*Service) *ExecutableSchema {
 	serviceMap := make(map[string]*Service)
+
 	for _, s := range services {
 		serviceMap[s.ServiceURL] = s
+	}
+
+	if client == nil {
+		client = NewClient()
 	}
 
 	return &ExecutableSchema{

--- a/execution.go
+++ b/execution.go
@@ -19,8 +19,8 @@ import (
 	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
-func newExecutableSchema(plugins []Plugin, maxRequestsPerQuery int64, services ...*Service) *ExecutableSchema {
-	client := NewClient()
+func newExecutableSchema(plugins []Plugin, maxRequestsPerQuery, maxResponseSize int64, services ...*Service) *ExecutableSchema {
+	client := NewClient(maxResponseSize)
 	serviceMap := make(map[string]*Service)
 	for _, s := range services {
 		serviceMap[s.ServiceURL] = s

--- a/execution_test.go
+++ b/execution_test.go
@@ -1969,7 +1969,7 @@ func (f *queryExecutionFixture) run(t *testing.T) {
 	merged, err := MergeSchemas(schemas...)
 	require.NoError(t, err)
 
-	es := newExecutableSchema(nil, 50, 1024*1024, services...)
+	es := newExecutableSchema(nil, 50, nil, services...)
 	es.MergedSchema = merged
 	es.Locations = buildFieldURLMap(services...)
 	es.IsBoundary = buildIsBoundaryMap(services...)

--- a/execution_test.go
+++ b/execution_test.go
@@ -1969,7 +1969,7 @@ func (f *queryExecutionFixture) run(t *testing.T) {
 	merged, err := MergeSchemas(schemas...)
 	require.NoError(t, err)
 
-	es := newExecutableSchema(nil, 50, services...)
+	es := newExecutableSchema(nil, 50, 1024*1024, services...)
 	es.MergedSchema = merged
 	es.Locations = buildFieldURLMap(services...)
 	es.IsBoundary = buildIsBoundaryMap(services...)

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -50,7 +50,7 @@ func TestGatewayQuery(t *testing.T) {
 			w.Write([]byte(`{ "data": { "test": "Hello" }}`))
 		}
 	}))
-	executableSchema := newExecutableSchema(nil, 50, &Service{ServiceURL: server.URL})
+	executableSchema := newExecutableSchema(nil, 50, 1024*1024, &Service{ServiceURL: server.URL})
 	err := executableSchema.UpdateSchema(true)
 	require.NoError(t, err)
 	gtw := NewGateway(executableSchema, []Plugin{})
@@ -71,7 +71,7 @@ func TestRequestJSONBodyLogging(t *testing.T) {
 	logrusLock.Lock()
 	defer logrusLock.Unlock()
 
-	server := NewGateway(newExecutableSchema(nil, 50), nil).Router()
+	server := NewGateway(newExecutableSchema(nil, 50, 1024*1024), nil).Router()
 
 	body := map[string]interface{}{
 		"foo": "bar",

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -50,7 +50,7 @@ func TestGatewayQuery(t *testing.T) {
 			w.Write([]byte(`{ "data": { "test": "Hello" }}`))
 		}
 	}))
-	executableSchema := newExecutableSchema(nil, 50, 1024*1024, &Service{ServiceURL: server.URL})
+	executableSchema := newExecutableSchema(nil, 50, nil, &Service{ServiceURL: server.URL})
 	err := executableSchema.UpdateSchema(true)
 	require.NoError(t, err)
 	gtw := NewGateway(executableSchema, []Plugin{})
@@ -71,7 +71,7 @@ func TestRequestJSONBodyLogging(t *testing.T) {
 	logrusLock.Lock()
 	defer logrusLock.Unlock()
 
-	server := NewGateway(newExecutableSchema(nil, 50, 1024*1024), nil).Router()
+	server := NewGateway(newExecutableSchema(nil, 50, nil), nil).Router()
 
 	body := map[string]interface{}{
 		"foo": "bar",

--- a/introspection.go
+++ b/introspection.go
@@ -34,7 +34,7 @@ func (s *Service) Update() (bool, error) {
 		} `json:"service"`
 	}{}
 
-	client := NewClient(1024 * 1024)
+	client := NewClient()
 	if err := client.Request(context.Background(), s.ServiceURL, req, &response); err != nil {
 		s.Status = "Unreachable"
 		return false, err

--- a/introspection.go
+++ b/introspection.go
@@ -34,7 +34,7 @@ func (s *Service) Update() (bool, error) {
 		} `json:"service"`
 	}{}
 
-	client := NewClient()
+	client := NewClient(1024 * 1024)
 	if err := client.Request(context.Background(), s.ServiceURL, req, &response); err != nil {
 		s.Status = "Unreachable"
 		return false, err


### PR DESCRIPTION
This allows you to specify in your initial config files a Client max-response-size for your GraphQL clients.
It will default to the old hard-coded value of 1MB (1024*1024)