### PR TITLE
Fix docker build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,7 +17,7 @@ jobs:
           go-version: 1.16
 
       - name: Build cmd
-        run: go build -o bramble ./cmd
+        run: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bramble ./cmd
 
       - name: Docker meta
         id: docker_meta


### PR DESCRIPTION
Fix the Docker image by building a static Bramble binary.

Fixes https://github.com/movio/bramble/issues/15