### PR TITLE
Fix id field being incorrectly added to some queries

### DIFF
--- a/execution_test.go
+++ b/execution_test.go
@@ -1136,7 +1136,7 @@ func TestQueryExecutionWithInputObject(t *testing.T) {
 							id
 							title
 							otherMovie(arg: {id: "2", title: "another title"}) {
-								_id: id title
+								title
 							}
 						}
 					}`, q["query"])

--- a/plan_fixtures_test.go
+++ b/plan_fixtures_test.go
@@ -20,9 +20,7 @@ type PlanTestFixture struct {
 
 var PlanTestFixture1 = &PlanTestFixture{
 	Schema: `
-	interface Node {
-		id: ID!
-	}
+	directive @boundary on OBJECT | FIELD_DEFINITION
 
 	enum Language {
 		French
@@ -30,13 +28,13 @@ var PlanTestFixture1 = &PlanTestFixture{
 		Italian
 	}
 
-	type Movie implements Node {
+	type Movie @boundary {
 		id: ID!
 		title(language: Language): String!
 		compTitles(limit: Int!): [Movie!]!
 	}
 
-	type Transaction implements Node {
+	type Transaction @boundary {
 		id: ID!
 		gross: Float!
 	}

--- a/plan_test.go
+++ b/plan_test.go
@@ -262,7 +262,7 @@ func TestQueryPlanInlineFragment(t *testing.T) {
 			{
 				"ServiceURL": "A",
 				"ParentType": "Query",
-				"SelectionSet": "{ movies { _id: id ... on Movie { id title(language: French) } } }",
+				"SelectionSet": "{ movies { ... on Movie { id title(language: French) } } }",
 				"InsertionPoint": null,
 				"Then": null
 			}
@@ -321,7 +321,7 @@ func TestQueryPlanFragmentSpread1(t *testing.T) {
 			{
 				"ServiceURL": "A",
 				"ParentType": "Query",
-				"SelectionSet": "{ movies { _id: id ... on Movie { id title(language: French) } } }",
+				"SelectionSet": "{ movies { ... on Movie { id title(language: French) } } }",
 				"InsertionPoint": null,
 				"Then": null
 			}
@@ -680,7 +680,7 @@ func TestQueryPlanWithNestedNamespaces(t *testing.T) {
 		  {
 			"ServiceURL": "A",
 			"ParentType": "Mutation",
-			"SelectionSet": "{ firstLevel { secondLevel { movie { id compTitles { id } releases { _id: id date } } } } }",
+			"SelectionSet": "{ firstLevel { secondLevel { movie { id compTitles { id } releases { date } } } } }",
 			"InsertionPoint": null,
 			"Then": [
 			  {
@@ -696,6 +696,22 @@ func TestQueryPlanWithNestedNamespaces(t *testing.T) {
 				"Then": null
 			  }
 			]
+		  }
+		]
+	  }
+	`)
+}
+
+func TestQueryPlanNoUnnessecaryID(t *testing.T) {
+	PlanTestFixture1.Check(t, "{ movies { title } }", `
+	  {
+		"RootSteps": [
+		  {
+			"ServiceURL": "A",
+			"ParentType": "Query",
+			"SelectionSet": "{ movies { title } }",
+			"InsertionPoint": null,
+			"Then": null
 		  }
 		]
 	  }


### PR DESCRIPTION
The id field was being included in the query even when not required, i.e. even when there is a single query step and the data is not going to be merged with another step.
And because in that case the result just gets forwarded as is, the field was not getting removed during formatting.

This fixes query planning to not add the id field when the data won't be merged, or in other words:
- The step is not a child step; AND
- The step doesn't have any child step