### PR TITLE
Fix inline fragment merge

### DIFF
--- a/execution.go
+++ b/execution.go
@@ -892,10 +892,12 @@ func mergeMaps(dst, src map[string]interface{}) {
 
 			switch value := v.(type) {
 			case json.RawMessage:
-				var m map[string]interface{}
+				// we want to unmarshal only what's necessary, so unmarshal only
+				// one level of the result
+				var m map[string]json.RawMessage
 				_ = json.Unmarshal([]byte(value), &m)
-				dst[k] = m
-				aValue = m
+				aValue = jsonMapToInterfaceMap(m)
+				dst[k] = aValue
 			case map[string]interface{}:
 				aValue = value
 			default:
@@ -904,9 +906,9 @@ func mergeMaps(dst, src map[string]interface{}) {
 
 			switch value := b.(type) {
 			case json.RawMessage:
-				var m map[string]interface{}
+				var m map[string]json.RawMessage
 				_ = json.Unmarshal([]byte(value), &m)
-				bValue = m
+				bValue = jsonMapToInterfaceMap(m)
 			case map[string]interface{}:
 				bValue = value
 			default:


### PR DESCRIPTION
When dealing with fragment spreads we usually want to pass the response from the client as is, because we don't necessarily know what type was matched. In order to do that we need to not unmarshal the response more than necessary.

So when merging results maps, unmarshal into a `map[string]json.RawMessage`  instead of `map[string]interface{}`, this way we recursively unmarshal only what's strictly necessary to do the merging.