### PR TITLE
Sort fields when marshalling AllowedFields

### DIFF
--- a/auth_test.go
+++ b/auth_test.go
@@ -44,6 +44,24 @@ func TestUnmarshalRoles(t *testing.T) {
 	require.Equal(t, roles, newroles)
 }
 
+func TestAllowedFieldsMarshallingOrder(t *testing.T) {
+	fields := AllowedFields{
+		AllowedSubfields: map[string]AllowedFields{
+			"a": {AllowAll: true},
+			"b": {AllowAll: true},
+			"c": {AllowAll: true},
+			"d": {AllowAll: true},
+		},
+	}
+
+	b1, err := json.Marshal(fields)
+	require.NoError(t, err)
+	b2, err := json.Marshal(fields)
+	require.NoError(t, err)
+
+	assert.Equal(t, b1, b2)
+}
+
 func TestFilterAuthorizedFields(t *testing.T) {
 	schemaStr := `
 	type Movie {


### PR DESCRIPTION
Sort fields when marshalling AllowedFields to ensure fields order is deterministic (Go maps order is random).
This will help when generating or displaying roles.