### PR TITLE
Better handling of execution errors

### DIFF
--- a/client.go
+++ b/client.go
@@ -131,7 +131,8 @@ type Response struct {
 type GraphqlErrors []GraphqlError
 
 type GraphqlError struct {
-	Message string `json:"message"`
+	Message    string                 `json:"message"`
+	Extensions map[string]interface{} `json:"extensions"`
 }
 
 func (e GraphqlErrors) Error() string {

--- a/execution.go
+++ b/execution.go
@@ -158,11 +158,11 @@ func (s *ExecutableSchema) ExecuteQuery(ctx context.Context) *graphql.Response {
 		errs = perms.FilterAuthorizedFields(op)
 	}
 
+	filteredSchema := s.MergedSchema
+	if hasPerms {
+		filteredSchema = perms.FilterSchema(s.MergedSchema)
+	}
 	for _, f := range selectionSetToFields(op.SelectionSet) {
-		filteredSchema := s.MergedSchema
-		if hasPerms {
-			filteredSchema = perms.FilterSchema(s.MergedSchema)
-		}
 		switch f.Name {
 		case "__type":
 			name := f.Arguments.ForName("name").Value.Raw


### PR DESCRIPTION
This makes the handling of execution errors a little bit nicer:
- Forward error extensions
- Add the query info (selection set, service name, service URL) to the extensions instead of in the error message.
I think this will make error messages a lot more readable.
For example instead of having:
```json
errors": [
    {
      "message": "error while querying $SERVICE_URL with $SELECTION_SET: $ERROR",
    }
]
```
We'll get
```json
errors": [
    {
      "message": "$ERROR",
      "extensions": {
           "serviceName": "$SERVICE_NAME",
           "serviceUrl": "$SERVICE_URL",
           "selectionSet": "$SELECTION_SET"
       }
    }
]
```

Not related but also fixed the schema getting filered too many times on each query.