### PR TITLE
Add max-age option to CORS plugin

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -21,6 +21,7 @@ Add `CORS` headers to queries.
     "allowed-origins": ["https://example.com"],
     "allowed-headers": ["X-Custom-Header"],
     "allow-credentials": true,
+    "max-age": 3600,
     "debug": true
   }
 }

--- a/plugins/cors.go
+++ b/plugins/cors.go
@@ -23,6 +23,7 @@ type CorsPluginConfig struct {
 	AllowedOrigins   []string `json:"allowed-origins"`
 	AllowedHeaders   []string `json:"allowed-headers"`
 	AllowCredentials bool     `json:"allow-credentials"`
+	MaxAge           int      `json:"max-age"`
 	Debug            bool     `json:"debug"`
 }
 
@@ -43,6 +44,7 @@ func (p *CorsPlugin) middleware(h http.Handler) http.Handler {
 		AllowedOrigins:   p.config.AllowedOrigins,
 		AllowedHeaders:   p.config.AllowedHeaders,
 		AllowCredentials: p.config.AllowCredentials,
+		MaxAge:           p.config.MaxAge,
 		Debug:            p.config.Debug,
 	})
 	if p.config.Debug {


### PR DESCRIPTION
Add `max-age` option to CORS plugin.
This indicates how long the result of the preflight request can be cached.