### PR TITLE
Include user agent in downstream queries

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,7 +17,7 @@ jobs:
           go-version: 1.16
 
       - name: Build cmd
-        run: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bramble ./cmd/bramble
+        run: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-X 'github.com/movio/bramble.version=$(git describe --tags --abbrev=0)'" -o bramble ./cmd/bramble
 
       - name: Docker meta
         id: docker_meta

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /bramble
 .vscode
 .history
+.idea
 coverage.out

--- a/client.go
+++ b/client.go
@@ -19,6 +19,7 @@ type GraphQLClient struct {
 	HTTPClient      *http.Client
 	MaxResponseSize int64
 	Tracer          opentracing.Tracer
+	UserAgent       string
 }
 
 type ClientOpt func(*GraphQLClient)
@@ -44,6 +45,12 @@ func WithMaxResponseSize(maxResponseSize int64) ClientOpt {
 	}
 }
 
+func WithUserAgent(userAgent string) ClientOpt {
+	return func(s *GraphQLClient) {
+		s.UserAgent = userAgent
+	}
+}
+
 func (c *GraphQLClient) Request(ctx context.Context, url string, request *Request, out interface{}) error {
 	var buf bytes.Buffer
 	err := json.NewEncoder(&buf).Encode(request)
@@ -62,6 +69,10 @@ func (c *GraphQLClient) Request(ctx context.Context, url string, request *Reques
 
 	httpReq.Header.Set("Content-Type", "application/json; charset=utf-8")
 	httpReq.Header.Set("Accept", "application/json; charset=utf-8")
+
+	if c.UserAgent != "" {
+		httpReq.Header.Set("User-Agent", c.UserAgent)
+	}
 
 	if c.Tracer != nil {
 		span := opentracing.SpanFromContext(ctx)

--- a/client.go
+++ b/client.go
@@ -153,3 +153,7 @@ func (e GraphqlErrors) Error() string {
 	}
 	return strings.Join(errs, ",")
 }
+
+func generateBrambleUserAgent(operation string) string {
+	return fmt.Sprintf("Bramble/%s (%s)", version, operation)
+}

--- a/config.go
+++ b/config.go
@@ -230,13 +230,15 @@ func (c *Config) Init() error {
 		return fmt.Errorf("error building service list: %w", err)
 	}
 
+	updateClient := NewClient(WithUserAgent(generateBrambleUserAgent("update")))
+
 	var services []*Service
 	for _, s := range c.Services {
-		services = append(services, NewService(s))
+		services = append(services, NewService(s, updateClient))
 	}
 
-	client := NewClient(WithMaxResponseSize(c.MaxServiceResponseSize))
-	es := newExecutableSchema(c.plugins, c.MaxRequestsPerQuery, client, services...)
+	queryClient := NewClient(WithMaxResponseSize(c.MaxServiceResponseSize), WithUserAgent(generateBrambleUserAgent("query")))
+	es := newExecutableSchema(c.plugins, c.MaxRequestsPerQuery, queryClient, services...)
 	err = es.UpdateSchema(true)
 	if err != nil {
 		return err

--- a/config.go
+++ b/config.go
@@ -12,6 +12,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+var version = "dev"
+
 type PluginConfig struct {
 	Name   string
 	Config json.RawMessage

--- a/config.go
+++ b/config.go
@@ -230,11 +230,9 @@ func (c *Config) Init() error {
 		return fmt.Errorf("error building service list: %w", err)
 	}
 
-	updateClient := NewClient(WithUserAgent(generateBrambleUserAgent("update")))
-
 	var services []*Service
 	for _, s := range c.Services {
-		services = append(services, NewService(s, updateClient))
+		services = append(services, NewService(s))
 	}
 
 	queryClient := NewClient(WithMaxResponseSize(c.MaxServiceResponseSize), WithUserAgent(generateBrambleUserAgent("query")))

--- a/execution.go
+++ b/execution.go
@@ -60,7 +60,7 @@ func (s *ExecutableSchema) UpdateServiceList(services []string) error {
 		if svc, ok := s.Services[svcURL]; ok {
 			newServices[svcURL] = svc
 		} else {
-			newServices[svcURL] = NewService(svcURL)
+			newServices[svcURL] = NewService(svcURL, NewClient(WithUserAgent(generateBrambleUserAgent("update"))))
 		}
 	}
 	s.Services = newServices

--- a/execution.go
+++ b/execution.go
@@ -60,7 +60,7 @@ func (s *ExecutableSchema) UpdateServiceList(services []string) error {
 		if svc, ok := s.Services[svcURL]; ok {
 			newServices[svcURL] = svc
 		} else {
-			newServices[svcURL] = NewService(svcURL, NewClient(WithUserAgent(generateBrambleUserAgent("update"))))
+			newServices[svcURL] = NewService(svcURL)
 		}
 	}
 	s.Services = newServices

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -50,7 +50,7 @@ func TestGatewayQuery(t *testing.T) {
 			w.Write([]byte(`{ "data": { "test": "Hello" }}`))
 		}
 	}))
-	executableSchema := newExecutableSchema(nil, 50, nil, &Service{ServiceURL: server.URL})
+	executableSchema := newExecutableSchema(nil, 50, nil, NewService(server.URL, nil))
 	err := executableSchema.UpdateSchema(true)
 	require.NoError(t, err)
 	gtw := NewGateway(executableSchema, []Plugin{})

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -46,11 +46,14 @@ func TestGatewayQuery(t *testing.T) {
 					}
 				}
 			}`, string(encodedSchema))
+			assert.Equal(t, "Bramble/dev (update)", r.Header.Get("User-Agent"))
 		} else {
 			w.Write([]byte(`{ "data": { "test": "Hello" }}`))
+			assert.Equal(t, "Bramble/dev (query)", r.Header.Get("User-Agent"))
 		}
 	}))
-	executableSchema := newExecutableSchema(nil, 50, nil, NewService(server.URL))
+	client := NewClient(WithUserAgent(generateBrambleUserAgent("query")))
+	executableSchema := newExecutableSchema(nil, 50, client, NewService(server.URL))
 	err := executableSchema.UpdateSchema(true)
 	require.NoError(t, err)
 	gtw := NewGateway(executableSchema, []Plugin{})

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -50,7 +50,7 @@ func TestGatewayQuery(t *testing.T) {
 			w.Write([]byte(`{ "data": { "test": "Hello" }}`))
 		}
 	}))
-	executableSchema := newExecutableSchema(nil, 50, nil, NewService(server.URL, nil))
+	executableSchema := newExecutableSchema(nil, 50, nil, NewService(server.URL))
 	err := executableSchema.UpdateSchema(true)
 	require.NoError(t, err)
 	gtw := NewGateway(executableSchema, []Plugin{})

--- a/introspection.go
+++ b/introspection.go
@@ -16,12 +16,20 @@ type Service struct {
 	SchemaSource string
 	Schema       *ast.Schema
 	Status       string
+
+	client *GraphQLClient
 }
 
-func NewService(serviceURL string) *Service {
-	return &Service{
+func NewService(serviceURL string, client *GraphQLClient) *Service {
+	s := &Service{
 		ServiceURL: serviceURL,
 	}
+	if client == nil {
+		s.client = NewClient()
+	} else {
+		s.client = client
+	}
+	return s
 }
 
 func (s *Service) Update() (bool, error) {
@@ -34,8 +42,7 @@ func (s *Service) Update() (bool, error) {
 		} `json:"service"`
 	}{}
 
-	client := NewClient()
-	if err := client.Request(context.Background(), s.ServiceURL, req, &response); err != nil {
+	if err := s.client.Request(context.Background(), s.ServiceURL, req, &response); err != nil {
 		s.Status = "Unreachable"
 		return false, err
 	}

--- a/introspection.go
+++ b/introspection.go
@@ -20,14 +20,10 @@ type Service struct {
 	client *GraphQLClient
 }
 
-func NewService(serviceURL string, client *GraphQLClient) *Service {
+func NewService(serviceURL string) *Service {
 	s := &Service{
 		ServiceURL: serviceURL,
-	}
-	if client == nil {
-		s.client = NewClient()
-	} else {
-		s.client = client
+		client:     NewClient(WithUserAgent(generateBrambleUserAgent("update"))),
 	}
 	return s
 }

--- a/middleware.go
+++ b/middleware.go
@@ -62,7 +62,7 @@ func debugMiddleware(h http.Handler) http.Handler {
 func monitoringMiddleware(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx, event := startEvent(r.Context(), "request")
-		if r.Header.Get("user-agent") != "bramble-healthcheck" {
+		if !strings.HasPrefix(r.Header.Get("user-agent"), "Bramble") {
 			defer event.finish()
 		}
 

--- a/plugins/opentracing.go
+++ b/plugins/opentracing.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/movio/bramble"
 	"github.com/opentracing/opentracing-go"
@@ -52,7 +53,7 @@ func (p *OpenTracingPlugin) Init(s *bramble.ExecutableSchema) {
 func (p *OpenTracingPlugin) ApplyMiddlewarePublicMux(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		// do not trace healthcheck
-		if r.Header.Get("user-agent") == "bramble-healthcheck" {
+		if strings.HasPrefix(r.Header.Get("user-agent"), "Bramble") {
 			h.ServeHTTP(rw, r)
 			return
 		}


### PR DESCRIPTION
Adds user agent in the format `Bramble/$version ($operation)` when performing queries. E.g when querying services for an updated schema we would see `Bramble/v1.16.0 (update)`. 