### PR TITLE
fix go build command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Prerequisite: Go 1.16 or newer
 To build the `bramble` command:
 
 ```bash
-go build -o bramble ./cmd
+go build -o bramble ./cmd/bramble
 ./bramble -conf config.json
 ```
 


### PR DESCRIPTION
go build command in README may need updating. 

looks to be introduced in #19 

