### PR TITLE
Set GraphQL client timeout when using the limits plugin

### DIFF
--- a/plugins/limits.go
+++ b/plugins/limits.go
@@ -32,6 +32,10 @@ func (p *LimitsPlugin) ID() string {
 	return "limits"
 }
 
+func (p *LimitsPlugin) Init(es *bramble.ExecutableSchema) {
+	es.GraphqlClient.HTTPClient.Timeout = p.config.maxResponseDuration
+}
+
 func (p *LimitsPlugin) Configure(cfg *bramble.Config, data json.RawMessage) error {
 	err := json.Unmarshal(data, &p.config)
 	if err != nil {


### PR DESCRIPTION
Set the GraphQL client timeout when using the `limits` plugin.
This avoids hitting the default client timeout when there's still time for the request to finish.