### PR TITLE
Preserve and use type information when marshalling fragment spreads

### DIFF
--- a/execution_test.go
+++ b/execution_test.go
@@ -21,6 +21,128 @@ import (
 	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
+func TestFederatedQueryFragmentSpreads(t *testing.T) {
+	serviceA := testService{
+		schema: `
+          directive @boundary on OBJECT
+          interface Snapshot {
+            id: ID!
+            name: String!
+          }
+
+          type Gizmo @boundary {
+            id: ID!
+          }
+
+          type SnapshotImplementation implements Snapshot {
+            id: ID!
+            name: String!
+            gizmos: [Gizmo!]!
+          }
+
+          type Query {
+            snapshot(id: ID!): Snapshot!
+          }`,
+		handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(`
+                    {
+                      "data": {
+                        "snapshot": {
+                          "id": "100",
+                          "name": "foo",
+                          "gizmos": [{ "id": "1" }]
+                        }
+                      }
+                    }`))
+		}),
+	}
+
+	serviceB := testService{
+		schema: `
+          directive @boundary on OBJECT
+          type Gizmo @boundary {
+            id: ID!
+            name: String!
+          }
+
+          type Query {
+            gizmo(id: ID!): Gizmo @boundary
+          }`,
+		handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(`
+                   {
+                     "data": {
+                       "_0": {
+                         "id": "1",
+                         "name": "Gizmo #1"
+                       }
+                     }
+                   }`))
+		}),
+	}
+
+	t.Run("with inline fragment spread", func(t *testing.T) {
+		f := &queryExecutionFixture{
+			services: []testService{serviceA, serviceB},
+			query: `
+              query Foo {
+                snapshot(id: "foo") {
+                  id
+                  name
+                  ... on SnapshotImplementation {
+                    gizmos {
+                      id
+                      name
+                    }
+                  }
+                }
+              }`,
+			expected: `
+              {
+                "snapshot": {
+                  "id": "100",
+                  "name": "foo",
+                  "gizmos": [{ "id": "1", "name": "Gizmo #1" }]
+                }
+              }`,
+		}
+
+		f.checkSuccess(t)
+	})
+
+	t.Run("with named fragment spread", func(t *testing.T) {
+		f := &queryExecutionFixture{
+			services: []testService{serviceA, serviceB},
+			query: `
+              query Foo {
+                snapshot(id: "foo") {
+                  id
+                  name
+                  ... NamedFragment
+                }
+              }
+
+              fragment NamedFragment on SnapshotImplementation {
+                gizmos {
+                  id
+                  name
+                }
+              }`,
+			expected: `
+              {
+                "snapshot": {
+                  "id": "100",
+                  "name": "foo",
+                  "gizmos": [{ "id": "1", "name": "Gizmo #1" }]
+                }
+              }`,
+		}
+
+		f.checkSuccess(t)
+	})
+
+}
+
 func TestIntrospectionQuery(t *testing.T) {
 	schema := `
 	union MovieOrCinema = Movie | Cinema


### PR DESCRIPTION
When marshalling the result of a federated query that contained a fragment spread we would hit an error in the marshalling logic. 

The added tests show the conditions needed to trigger the problem but the gist is that the information needed to know when inside the context of a fragment spread was being thrown out. This caused the marshalling logic to look up type information on the interface and not the target type of the spread.

The fix for now is to intercept the call that flattens out fragments and preserve the `TypeCondition` of the fragment. Longer term we might want to consider a refactor of the `marshalResult` function