### PR TITLE
Don't remarshal already marshalled json

### DIFF
--- a/format.go
+++ b/format.go
@@ -231,6 +231,8 @@ func marshalResult(data interface{}, selectionSet ast.SelectionSet, schema *ast.
 	}
 
 	switch data := data.(type) {
+	case json.RawMessage:
+		return data, nil
 	case map[string]interface{}:
 		if data == nil {
 			return []byte("null"), nil


### PR DESCRIPTION
When marshalling the result from a single service the type that gets passed into `marshalResult` is already `json.RawMessage`. This was being caught by the default case and causing a second and unnecessary `json.Marshal` call. While not a big deal for most use cases this could be a noticeable overhead with large responses.