### PR TITLE
DOC: fixed typo on installation url.

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -39,7 +39,7 @@ For the full list of available options see [configuration](configuration.md).
 (requires Golang)
 
 ```
-go install https://github.com/movio/bramble/cmd/bramble@latest
+go install github.com/movio/bramble/cmd/bramble@latest
 ```
 
 ```


### PR DESCRIPTION
Go does not accept any protocol on package address. 
Fixed this error on installation in this commit `malformed import path "https:/github.com/movio/bramble/cmd/bramble": invalid char ':'`