### PR TITLE
Add network interface fields to configs.

### DIFF
--- a/config.go
+++ b/config.go
@@ -22,6 +22,9 @@ type PluginConfig struct {
 
 // Config contains the gateway configuration
 type Config struct {
+	GatewayInterface       string    `json:"gateway-interface"`
+	MetricsInterface       string    `json:"metrics-interface"`
+	PrivateInterface       string    `json:"private-interface"`
 	GatewayPort            int       `json:"gateway-port"`
 	MetricsPort            int       `json:"metrics-port"`
 	PrivatePort            int       `json:"private-port"`
@@ -44,17 +47,17 @@ type Config struct {
 
 // GatewayAddress returns the host:port string of the gateway
 func (c *Config) GatewayAddress() string {
-	return fmt.Sprintf(":%d", c.GatewayPort)
+	return fmt.Sprintf("%s:%d", c.GatewayInterface, c.GatewayPort)
 }
 
 // PrivateAddress returns the address for private port
 func (c *Config) PrivateAddress() string {
-	return fmt.Sprintf(":%d", c.PrivatePort)
+	return fmt.Sprintf("%s:%d", c.PrivateInterface, c.PrivatePort)
 }
 
 // MetricAddress returns the address for the metric port
 func (c *Config) MetricAddress() string {
-	return fmt.Sprintf(":%d", c.MetricsPort)
+	return fmt.Sprintf("%s:%d", c.MetricsInterface, c.MetricsPort)
 }
 
 // Load loads or reloads all the config files.

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,37 @@
+package bramble
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig(t *testing.T) {
+	t.Run("no interface provided", func(t *testing.T) {
+		cfg := new(Config)
+		cfg.GatewayPort = 8082
+		cfg.PrivatePort = 8083
+		cfg.MetricsPort = 8084
+		gAddress := cfg.GatewayAddress()
+		require.Equal(t, ":8082", gAddress)
+		pAddress := cfg.PrivateAddress()
+		require.Equal(t, ":8083", pAddress)
+		mAddress := cfg.MetricAddress()
+		require.Equal(t, ":8084", mAddress)
+	})
+	t.Run("network interface provided", func(t *testing.T) {
+		cfg := new(Config)
+		cfg.GatewayInterface = "0.0.0.0"
+		cfg.GatewayPort = 8082
+		cfg.PrivateInterface = "127.0.0.1"
+		cfg.PrivatePort = 8083
+		cfg.MetricsInterface = "192.0.0.1"
+		cfg.MetricsPort = 8084
+		gAddress := cfg.GatewayAddress()
+		require.Equal(t, "0.0.0.0:8082", gAddress)
+		pAddress := cfg.PrivateAddress()
+		require.Equal(t, "127.0.0.1:8083", pAddress)
+		mAddress := cfg.MetricAddress()
+		require.Equal(t, "192.0.0.1:8084", mAddress)
+	})
+}


### PR DESCRIPTION
The listen address should be string. But current configuration file accepts (only) network ports as integer. And then converts it to listen address. `(":%s", port)`

In this commit I have added a way to specifically provide network interface to listen. 
I wanted to make it full string. Instead of accepting port as integer, it should accept the whole network interface like `localhost:8080` or `0.0.0.0:8080`.

**For backward compatibility**, I just added a way to specify network interface addresses. 
From now users can specify what interface they want Bramble to listen. But the interface and port have to be in different fields. (will probably get fixed in v2).

Solves #65