### PR TITLE
Allow specifying the full listen address in config

### DIFF
--- a/config.go
+++ b/config.go
@@ -22,6 +22,9 @@ type PluginConfig struct {
 
 // Config contains the gateway configuration
 type Config struct {
+	GatewayInterface       string    `json:"gateway-interface"`
+	MetricsInterface       string    `json:"metrics-interface"`
+	PrivateInterface       string    `json:"private-interface"`
 	GatewayPort            int       `json:"gateway-port"`
 	MetricsPort            int       `json:"metrics-port"`
 	PrivatePort            int       `json:"private-port"`
@@ -44,17 +47,17 @@ type Config struct {
 
 // GatewayAddress returns the host:port string of the gateway
 func (c *Config) GatewayAddress() string {
-	return fmt.Sprintf(":%d", c.GatewayPort)
+	return fmt.Sprintf("%s:%d", c.GatewayInterface, c.GatewayPort)
 }
 
 // PrivateAddress returns the address for private port
 func (c *Config) PrivateAddress() string {
-	return fmt.Sprintf(":%d", c.PrivatePort)
+	return fmt.Sprintf("%s:%d", c.PrivateInterface, c.PrivatePort)
 }
 
 // MetricAddress returns the address for the metric port
 func (c *Config) MetricAddress() string {
-	return fmt.Sprintf(":%d", c.MetricsPort)
+	return fmt.Sprintf("%s:%d", c.MetricsInterface, c.MetricsPort)
 }
 
 // Load loads or reloads all the config files.

--- a/config_test.go
+++ b/config_test.go
@@ -19,19 +19,26 @@ func TestConfig(t *testing.T) {
 		mAddress := cfg.MetricAddress()
 		require.Equal(t, ":8084", mAddress)
 	})
-	t.Run("network interface provided", func(t *testing.T) {
+	t.Run("network address provided", func(t *testing.T) {
 		cfg := new(Config)
-		cfg.GatewayInterface = "0.0.0.0"
-		cfg.GatewayPort = 8082
-		cfg.PrivateInterface = "127.0.0.1"
+		cfg.GatewayListenAddress = "0.0.0.0:8082"
+		cfg.GatewayPort = 0
+		cfg.PrivateListenAddress = "127.0.0.1:8084"
 		cfg.PrivatePort = 8083
-		cfg.MetricsInterface = "192.0.0.1"
+		cfg.MetricsListenAddress = ""
 		cfg.MetricsPort = 8084
 		gAddress := cfg.GatewayAddress()
 		require.Equal(t, "0.0.0.0:8082", gAddress)
 		pAddress := cfg.PrivateAddress()
-		require.Equal(t, "127.0.0.1:8083", pAddress)
+		require.Equal(t, "127.0.0.1:8084", pAddress)
 		mAddress := cfg.MetricAddress()
-		require.Equal(t, "192.0.0.1:8084", mAddress)
+		require.Equal(t, ":8084", mAddress)
+	})
+	t.Run("private http address for plugin services", func(t *testing.T) {
+		cfg := new(Config)
+		cfg.PrivatePort = 8083
+		require.Equal(t, "http://localhost:8083/plugin", cfg.PrivateHttpAddress("plugin"))
+		cfg.PrivateListenAddress = "127.0.0.1:8084"
+		require.Equal(t, "http://127.0.0.1:8084/plugin", cfg.PrivateHttpAddress("plugin"))
 	})
 }

--- a/config_test.go
+++ b/config_test.go
@@ -7,36 +7,33 @@ import (
 )
 
 func TestConfig(t *testing.T) {
-	t.Run("no interface provided", func(t *testing.T) {
-		cfg := new(Config)
-		cfg.GatewayPort = 8082
-		cfg.PrivatePort = 8083
-		cfg.MetricsPort = 8084
-		gAddress := cfg.GatewayAddress()
-		require.Equal(t, ":8082", gAddress)
-		pAddress := cfg.PrivateAddress()
-		require.Equal(t, ":8083", pAddress)
-		mAddress := cfg.MetricAddress()
-		require.Equal(t, ":8084", mAddress)
+	t.Run("port provided", func(t *testing.T) {
+		cfg := &Config{
+			GatewayPort: 8082,
+			PrivatePort: 8083,
+			MetricsPort: 8084,
+		}
+		require.Equal(t, ":8082", cfg.GatewayAddress())
+		require.Equal(t, ":8083", cfg.PrivateAddress())
+		require.Equal(t, ":8084", cfg.MetricAddress())
 	})
-	t.Run("network address provided", func(t *testing.T) {
-		cfg := new(Config)
-		cfg.GatewayListenAddress = "0.0.0.0:8082"
-		cfg.GatewayPort = 0
-		cfg.PrivateListenAddress = "127.0.0.1:8084"
-		cfg.PrivatePort = 8083
-		cfg.MetricsListenAddress = ""
-		cfg.MetricsPort = 8084
-		gAddress := cfg.GatewayAddress()
-		require.Equal(t, "0.0.0.0:8082", gAddress)
-		pAddress := cfg.PrivateAddress()
-		require.Equal(t, "127.0.0.1:8084", pAddress)
-		mAddress := cfg.MetricAddress()
-		require.Equal(t, ":8084", mAddress)
+	t.Run("address provided and prefered over port", func(t *testing.T) {
+		cfg := &Config{
+			GatewayListenAddress: "0.0.0.0:8082",
+			GatewayPort:          0,
+			PrivateListenAddress: "127.0.0.1:8084",
+			PrivatePort:          8083,
+			MetricsListenAddress: "",
+			MetricsPort:          8084,
+		}
+		require.Equal(t, "0.0.0.0:8082", cfg.GatewayAddress())
+		require.Equal(t, "127.0.0.1:8084", cfg.PrivateAddress())
+		require.Equal(t, ":8084", cfg.MetricAddress())
 	})
 	t.Run("private http address for plugin services", func(t *testing.T) {
-		cfg := new(Config)
-		cfg.PrivatePort = 8083
+		cfg := &Config{
+			PrivatePort: 8083,
+		}
 		require.Equal(t, "http://localhost:8083/plugin", cfg.PrivateHttpAddress("plugin"))
 		cfg.PrivateListenAddress = "127.0.0.1:8084"
 		require.Equal(t, "http://127.0.0.1:8084/plugin", cfg.PrivateHttpAddress("plugin"))

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,37 @@
+package bramble
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig(t *testing.T) {
+	t.Run("no interface provided", func(t *testing.T) {
+		cfg := new(Config)
+		cfg.GatewayPort = 8082
+		cfg.PrivatePort = 8083
+		cfg.MetricsPort = 8084
+		gAddress := cfg.GatewayAddress()
+		require.Equal(t, ":8082", gAddress)
+		pAddress := cfg.PrivateAddress()
+		require.Equal(t, ":8083", pAddress)
+		mAddress := cfg.MetricAddress()
+		require.Equal(t, ":8084", mAddress)
+	})
+	t.Run("network interface provided", func(t *testing.T) {
+		cfg := new(Config)
+		cfg.GatewayInterface = "0.0.0.0"
+		cfg.GatewayPort = 8082
+		cfg.PrivateInterface = "127.0.0.1"
+		cfg.PrivatePort = 8083
+		cfg.MetricsInterface = "192.0.0.1"
+		cfg.MetricsPort = 8084
+		gAddress := cfg.GatewayAddress()
+		require.Equal(t, "0.0.0.0:8082", gAddress)
+		pAddress := cfg.PrivateAddress()
+		require.Equal(t, "127.0.0.1:8083", pAddress)
+		mAddress := cfg.MetricAddress()
+		require.Equal(t, "192.0.0.1:8084", mAddress)
+	})
+}


### PR DESCRIPTION
Adapted from the changes suggested by @hsblhsn in #66 but I decided it was better to allow the newer config field to fully specify the listen addresses and fallback to just the port on the unspecified address if that was all that was provided.