### PR TITLE
Don't error out when all fragment expansions miss

### DIFF
--- a/query_execution.go
+++ b/query_execution.go
@@ -844,10 +844,6 @@ func unionAndTrimSelectionSetRec(objectTypename string, schema *ast.Schema, sele
 			filteredSelectionSet = append(filteredSelectionSet, selection)
 		case *ast.InlineFragment:
 			fragment := selection
-			if objectTypename == "" {
-				return nil, errors.New("unionAndTrimSelectionSetRec: expected __typename")
-			}
-
 			if fragment.ObjectDefinition.IsAbstractType() &&
 				fragmentImplementsAbstractType(schema, fragment.ObjectDefinition.Name, fragment.TypeCondition) &&
 				objectTypenameMatchesDifferentFragment(objectTypename, fragment) {


### PR DESCRIPTION
Upstream, in the query planning stage, `__typename` fields are injected for inline fragment spread queries, this is what the execution result set merge relies on to know which fragment expansion selection set is relevant to the associated response.

An error was returned when, inside a fragment query, the corresponding response would not contain this `__typename` field - presumably to safeguard the assumption the upstream query planning stage behaved as expected.

The problem here is when you have a query with fragment expansions that _missed_ the response entirely (see added test for example). When a _miss_ like this happens, we should leave `""` to represent the response `__typename` as per `extractAndCastTypenameField(result)` to indicate every fragment selection set in the query will not be resolved.