### PR TITLE
Fix: expand all possible abstract ids

### DIFF
--- a/plan_test.go
+++ b/plan_test.go
@@ -408,6 +408,27 @@ func TestQueryPlanFragmentSpread2(t *testing.T) {
 	PlanTestFixture1.Check(t, query, plan)
 }
 
+func TestQueryPlanExpandAbstractTypesWithPossibleBoundaryIds(t *testing.T) {
+	query := `
+	{
+		animals {
+			name
+		}
+	}`
+	plan := `{
+		"RootSteps": [
+			{
+				"ServiceURL": "A",
+				"ParentType": "Query",
+				"SelectionSet": "{ animals { ... on Snake { _id: id } ... on Lion { _id: id } name } }",
+				"InsertionPoint": null,
+				"Then": null
+			}
+		]
+	}`
+	PlanTestFixture3.Check(t, query, plan)
+}
+
 func TestQueryPlanInlineFragmentSpreadOfInterface(t *testing.T) {
 	query := `
 	{
@@ -426,7 +447,7 @@ func TestQueryPlanInlineFragmentSpreadOfInterface(t *testing.T) {
 			{
 				"ServiceURL": "A",
 				"ParentType": "Query",
-				"SelectionSet": "{ animals { name ... on Lion { maneColor __typename } ... on Snake { _id: id __typename } } }",
+				"SelectionSet": "{ animals { ... on Snake { _id: id } ... on Lion { _id: id } name ... on Lion { maneColor __typename } ... on Snake { _id: id __typename } } }",
 				"InsertionPoint": null,
 				"Then": [
 					{


### PR DESCRIPTION
This fixes a bug with the notoriously tricky hint selections of abstract types. 

## The problem

Here's a schema...

```graphql
type Apple @boundary {
  id: ID!
  name: String!
}
type Banana @boundary {
  id: ID!
  name: String!
}
union Fruit = Apple | Banana

type Query {
  fruit: Fruit
}
```

Then here's a query:

```graphql
query {
  fruit {
    ...on Apple { name }
  }
}
```

This query works fine if the endpoint returns an `Apple`, but it fails if a `Banana` is returned:

```json
{
  "errors": [
    {
      "message": "boundaryIDFromMap: 'id' or '_id' not found"
    }
  ],
  "data": null
}
```

Why does a `Banana` fail? It's because ID hint selections are only being added to _user-defined boundary fragments_, i.e: `Apple`. In the above selection, the user hasn't explicitly made a `Banana` selection, so there's no ID hint added for a banana. That means that when a `Banana` gets is returned, the executor comes up with a boundary type that returned no ID.

## The fix

This updates the query planner to expand abstract types with ID selection hints for all possible boundary types. The above request now comes out looking like this:

```graphql
query {
  fruit {
    ... on Apple {
      _id: id
    }
    ... on Banana {
      _id: id
    }
    ... on Apple {
      name
    }
  }
}
```

Now, regardless of what the user has selected, we know that all possible boundary results will come back with the expected ID. [GraphQL Tools stitching](https://github.com/ardatan/graphql-tools) does something very similar. It's generally better to normalize the request than to make complicated assumptions about the result.

**Gross, there's now two `...on Apple` fragments, can we consolidate those?** Sure, we _could_ using something like [selectionSetHasFieldNamed](https://github.com/gmac/bramble/blob/eda96f845882405193f1bc4262f8b54b4d5d8626/plan.go#L353-L361) for fragments. However, I'm generally against adding loops for the sake of human cosmetics when GraphQL servers don't care if fragments or fields get duplicated in the selection. But if there's strong resistance to this, I'm happy to prettify it.

## Tests

Opening this now for initial review on the implementation... I'm still learning Go, so I'm a bit slow to write code and still have to figure out how to write/run tests.