### PR TITLE
Fix: fully traverse nested field selections while planning

### DIFF
--- a/plan.go
+++ b/plan.go
@@ -117,6 +117,7 @@ func createSteps(ctx *PlanningContext, insertionPoint []string, parentType, pare
 func extractSelectionSet(ctx *PlanningContext, insertionPoint []string, parentType string, input ast.SelectionSet, location string, childstep bool) (ast.SelectionSet, []*QueryPlanStep, error) {
 	var selectionSetResult []ast.Selection
 	var childrenStepsResult []*QueryPlanStep
+	var remoteSelections []ast.Selection
 	for _, selection := range input {
 		switch selection := selection.(type) {
 		case *ast.Field:
@@ -136,44 +137,29 @@ func extractSelectionSet(ctx *PlanningContext, insertionPoint []string, parentTy
 				childrenStepsResult = append(childrenStepsResult, steps...)
 				continue
 			}
-			if loc == location {
-				if selection.SelectionSet == nil {
-					selectionSetResult = append(selectionSetResult, selection)
-				} else {
-					newField := *selection
-					selectionSet, childrenSteps, err := extractSelectionSet(
-						ctx,
-						append(insertionPoint, selection.Alias),
-						selection.Definition.Type.Name(),
-						selection.SelectionSet,
-						location,
-						childstep,
-					)
-					if err != nil {
-						return nil, nil, err
-					}
-					newField.SelectionSet = selectionSet
-					selectionSetResult = append(selectionSetResult, &newField)
-					childrenStepsResult = append(childrenStepsResult, childrenSteps...)
-				}
+			if loc != location {
+				// field transitions to another service location
+				remoteSelections = append(remoteSelections, selection)
+			} else if selection.SelectionSet == nil {
+				// field is a leaf type in the current service
+				selectionSetResult = append(selectionSetResult, selection)
 			} else {
-				mergedWithExistingStep := false
-				for _, step := range childrenStepsResult {
-					if stringArraysEqual(step.InsertionPoint, insertionPoint) && step.ServiceURL == loc {
-						step.SelectionSet = append(step.SelectionSet, selection)
-						mergedWithExistingStep = true
-						break
-					}
+				// field is a composite type in the current service
+				newField := *selection
+				selectionSet, childrenSteps, err := extractSelectionSet(
+					ctx,
+					append(insertionPoint, selection.Alias),
+					selection.Definition.Type.Name(),
+					selection.SelectionSet,
+					location,
+					childstep,
+				)
+				if err != nil {
+					return nil, nil, err
 				}
-
-				if !mergedWithExistingStep {
-					newSelectionSet := []ast.Selection{selection}
-					childrenSteps, err := createSteps(ctx, insertionPoint, parentType, location, newSelectionSet, true)
-					if err != nil {
-						return nil, nil, err
-					}
-					childrenStepsResult = append(childrenStepsResult, childrenSteps...)
-				}
+				newField.SelectionSet = selectionSet
+				selectionSetResult = append(selectionSetResult, &newField)
+				childrenStepsResult = append(childrenStepsResult, childrenSteps...)
 			}
 		case *ast.InlineFragment:
 			selectionSet, childrenSteps, err := extractSelectionSet(
@@ -218,6 +204,15 @@ func extractSelectionSet(ctx *PlanningContext, insertionPoint []string, parentTy
 		default:
 			return nil, nil, fmt.Errorf("unexpected %T in SelectionSet", selection)
 		}
+	}
+
+	// Create child steps for all remote field selections
+	if len(remoteSelections) > 0 {
+		childrenSteps, err := createSteps(ctx, insertionPoint, parentType, location, remoteSelections, true)
+		if err != nil {
+			return nil, nil, err
+		}
+		childrenStepsResult = append(childrenStepsResult, childrenSteps...)
 	}
 
 	parentDef := ctx.Schema.Types[parentType]
@@ -380,20 +375,6 @@ func (m FieldURLMap) RegisterURL(parent string, field string, location string) {
 
 func (m FieldURLMap) keyFor(parent string, field string) string {
 	return fmt.Sprintf("%s.%s", parent, field)
-}
-
-func stringArraysEqual(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-
-	for i, v := range a {
-		if v != b[i] {
-			return false
-		}
-	}
-
-	return true
 }
 
 // BoundaryField contains the name and format for a boundary query

--- a/plan_fixtures_test.go
+++ b/plan_fixtures_test.go
@@ -220,6 +220,47 @@ var PlanTestFixture5 = &PlanTestFixture{
 	},
 }
 
+var PlanTestFixture6 = &PlanTestFixture{
+	Schema: `
+	type Shop {
+		id: ID!
+		name: String!
+		products: [Product]!
+	}
+
+	type Product {
+		id: ID!
+		name: String!
+		collection: Collection
+	}
+
+	type Collection {
+		id: ID!
+		name: String!
+	}
+
+	type Query {
+		shop1: Shop!
+	}`,
+
+	Locations: map[string]string{
+		"Query.shop1":         "A",
+		"Shop.id":             "A",
+		"Shop.name":           "A",
+		"Shop.products":       "A",
+		"Product.name":        "B",
+		"Product.collection":  "B",
+		"Collection.name":     "C",
+	},
+
+	IsBoundary: map[string]bool{
+		"Shop":        false,
+		"Product":     true,
+		"Collection":  true,
+	},
+}
+
+
 func (f *PlanTestFixture) Check(t *testing.T, query, expectedJSON string) {
 	t.Helper()
 	schema := gqlparser.MustLoadSchema(&ast.Source{Name: "fixture", Input: f.Schema})

--- a/plan_test.go
+++ b/plan_test.go
@@ -118,7 +118,7 @@ func TestQueryPlanABA2(t *testing.T) {
 				"SelectionSet": "{ _id: id compTitles(limit: 42) { id compTitles(limit: 666) { id } } }",
 				"InsertionPoint": ["movies"],
 				"Then": [
-					{
+				  {
 					"ServiceURL": "A",
 					"ParentType": "Movie",
 					"SelectionSet": "{ _id: id title }",
@@ -408,7 +408,7 @@ func TestQueryPlanFragmentSpread2(t *testing.T) {
 	PlanTestFixture1.Check(t, query, plan)
 }
 
-func TestQueryPlanMergeDeepTraversal(t *testing.T) {
+func TestQueryPlanCompleteDeepTraversal(t *testing.T) {
 	query := `
 	{
 		shop1 {
@@ -443,6 +443,40 @@ func TestQueryPlanMergeDeepTraversal(t *testing.T) {
 							"Then": null
 							}
 						]
+					}
+				]
+			}
+		]
+	}`
+	PlanTestFixture6.Check(t, query, plan)
+}
+
+func TestQueryPlanMergeInsertionPointSteps(t *testing.T) {
+	query := `
+	{
+		shop1 {
+			products {
+				name
+			}
+			products {
+				name
+			}
+		}
+	}`
+	plan := `{
+		"RootSteps": [
+			{
+				"ServiceURL": "A",
+				"ParentType": "Query",
+				"SelectionSet": "{ shop1 { products { _id: id } products { _id: id } } }",
+				"InsertionPoint": null,
+				"Then": [
+					{
+					"ServiceURL": "B",
+					"ParentType": "Product",
+					"SelectionSet": "{ _id: id name _id: id name }",
+					"InsertionPoint": ["shop1", "products"],
+					"Then": null
 					}
 				]
 			}
@@ -490,7 +524,7 @@ func TestQueryPlanInlineFragmentSpreadOfInterface(t *testing.T) {
 			{
 				"ServiceURL": "A",
 				"ParentType": "Query",
-				"SelectionSet": "{ animals { ... on Snake { _id: id } ... on Lion { _id: id } name ... on Lion { maneColor __typename } ... on Snake { _id: id __typename } } }",
+				"SelectionSet": "{ animals { ... on Lion { _id: id } ... on Snake { _id: id } name ... on Lion { maneColor __typename } ... on Snake { _id: id __typename } } }",
 				"InsertionPoint": null,
 				"Then": [
 					{

--- a/plan_test.go
+++ b/plan_test.go
@@ -524,7 +524,7 @@ func TestQueryPlanInlineFragmentSpreadOfInterface(t *testing.T) {
 			{
 				"ServiceURL": "A",
 				"ParentType": "Query",
-				"SelectionSet": "{ animals { ... on Lion { _id: id } ... on Snake { _id: id } name ... on Lion { maneColor __typename } ... on Snake { _id: id __typename } } }",
+				"SelectionSet": "{ animals { ... on Snake { _id: id } ... on Lion { _id: id } name ... on Lion { maneColor __typename } ... on Snake { _id: id __typename } } }",
 				"InsertionPoint": null,
 				"Then": [
 					{


### PR DESCRIPTION
As described in https://github.com/movio/bramble/issues/73, deeply-nested selection paths that transitioned between services were broken. This was a fairly significant issue.

## The problem

While extracting selection sets, the `mergedWithExistingStep` check was [treating _all_ consolidated fields as leaf values](https://github.com/movio/bramble/compare/main...gmac:fix-child-step-merging?expand=1#diff-11ffedf6a81044546aa19c8009998208f5a7afec3cdff04ca4281117b5ec0da7L163). That means that when a composite field was encountered with its own nested selections, that entire selection set was merged into the current planning step without traversing its children to delegate them properly. This resulted in fields belonging to foreign services getting lumped into the present service selection, and the query failing with a GraphQL validation message:

```
Cannot query field <remoteField> on type <LocalType>
```

## The fix

This adjusts the flow of `extractSelectionSet` so that all remote fields are collected up front and then create steps once together later in the process. This eliminates the need for the previous step-merging pattern, and is computationally simpler to create steps all at once rather than creating them incrementally for each remote step in sequence.

Note that this refactor looks bigger than it really is: this simplification was able to remove some conditional nesting and thus decrease the indent on a few existing code blocks. 

## Tests

Tests have been added. There's one update to an existing test where a benign array order has changed due to the revised sequencing of extracting remote fields. 

Resolves https://github.com/movio/bramble/issues/73.