### PR TITLE
Fix: spurious test failures caused by #81

### DIFF
--- a/plan_test.go
+++ b/plan_test.go
@@ -492,18 +492,12 @@ func TestQueryPlanExpandAbstractTypesWithPossibleBoundaryIds(t *testing.T) {
 			name
 		}
 	}`
-	plan := `{
-		"RootSteps": [
-			{
-				"ServiceURL": "A",
-				"ParentType": "Query",
-				"SelectionSet": "{ animals { ... on Snake { _id: id } ... on Lion { _id: id } name } }",
-				"InsertionPoint": null,
-				"Then": null
-			}
-		]
-	}`
-	PlanTestFixture3.Check(t, query, plan)
+	rootFieldSelections := []string{
+		"name",
+		"... on Lion { _id: id }",
+		"... on Snake { _id: id }",
+	}
+	PlanTestFixture3.CheckUnorderedRootFieldSelections(t, query, rootFieldSelections)
 }
 
 func TestQueryPlanInlineFragmentSpreadOfInterface(t *testing.T) {
@@ -519,26 +513,14 @@ func TestQueryPlanInlineFragmentSpreadOfInterface(t *testing.T) {
 			}
 		}
 	}`
-	plan := `{
-		"RootSteps": [
-			{
-				"ServiceURL": "A",
-				"ParentType": "Query",
-				"SelectionSet": "{ animals { ... on Snake { _id: id } ... on Lion { _id: id } name ... on Lion { maneColor __typename } ... on Snake { _id: id __typename } } }",
-				"InsertionPoint": null,
-				"Then": [
-					{
-						"ServiceURL": "B",
-						"ParentType": "Snake",
-						"SelectionSet": "{ _id: id venomous }",
-						"InsertionPoint": ["animals"],
-						"Then": null
-					}
-				]
-			}
-		]
-	}`
-	PlanTestFixture3.Check(t, query, plan)
+	rootFieldSelections := []string{
+		"name",
+		"... on Lion { _id: id }",
+		"... on Snake { _id: id }",
+		"... on Lion { maneColor __typename }",
+		"... on Snake { _id: id __typename }",
+	}
+	PlanTestFixture3.CheckUnorderedRootFieldSelections(t, query, rootFieldSelections)
 }
 
 func TestQueryPlanSkipDirective(t *testing.T) {


### PR DESCRIPTION
Fixes the inconsistent test failures introduced by #81. That PR tested selection sets generated from an unordered map enumeration; as such, the tests fail periodically when the unordered enumeration doesn't match the way the tests were written.

This introduces a new `CheckUnorderedRootFieldSelections` helper that accepts an array of selections and assures that they're each found within the planned result's root field, regardless of appearance order.

Resolves https://github.com/movio/bramble/issues/88.