### PR TITLE
Always add __typename to abstract types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 .vscode
 .history
 .idea
+.DS_Store
 coverage.out

--- a/plan.go
+++ b/plan.go
@@ -262,6 +262,11 @@ func extractSelectionSet(ctx *PlanningContext, insertionPoint []string, parentTy
 				break
 			}
 		}
+		selectionSetResult = append(selectionSetResult, &ast.Field{
+			Alias: "__typename",
+			Name: "__typename",
+			Definition: &ast.FieldDefinition{Name: "__typename", Type: ast.NamedType("String", nil)},
+		})
 	// Otherwise, add an id selection to boundary types where the result
 	// will be merged with another step (i.e.: has children or is a child step).
 	} else if parentType != queryObjectName &&

--- a/plan_test.go
+++ b/plan_test.go
@@ -496,6 +496,7 @@ func TestQueryPlanExpandAbstractTypesWithPossibleBoundaryIds(t *testing.T) {
 		"name",
 		"... on Lion { _id: id }",
 		"... on Snake { _id: id }",
+		"__typename",
 	}
 	PlanTestFixture3.CheckUnorderedRootFieldSelections(t, query, rootFieldSelections)
 }
@@ -519,6 +520,7 @@ func TestQueryPlanInlineFragmentSpreadOfInterface(t *testing.T) {
 		"... on Snake { _id: id }",
 		"... on Lion { maneColor __typename }",
 		"... on Snake { _id: id __typename }",
+		"__typename",
 	}
 	PlanTestFixture3.CheckUnorderedRootFieldSelections(t, query, rootFieldSelections)
 }
@@ -638,7 +640,7 @@ func TestQueryPlanSupportsUnions(t *testing.T) {
         {
           "ServiceURL": "A",
           "ParentType": "Query",
-          "SelectionSet": "{ animals { ... on Dog { name __typename } ... on Cat { name __typename } ... on Snake { name __typename } } }",
+          "SelectionSet": "{ animals { ... on Dog { name __typename } ... on Cat { name __typename } ... on Snake { name __typename } __typename } }",
           "InsertionPoint": null,
           "Then": null
         }


### PR DESCRIPTION
Preemptively fixing the same issue described in https://github.com/movio/bramble/pull/81, but with `__typename`...

## The (potential) problem

Given that the execution resolver uses `__typename` while assembling abstract types, we need to assure that a typename is always returned. However, the automated `__typename` hints are currently only added to _user-defined_ fragments, and those aren't guaranteed to be present when making abstract type selections (case of point: selecting base interface fields).

While I haven't actually made this scenario fail, I strongly suspect that it can be broken.

## The (preemptive) fix

This adds `__typename` to all abstract types. In the event that the user doesn't make a fragment selection on an abstract, the selection will still request typename for resolution purposes.