### PR TITLE
Fix: validate reserved field aliases

### DIFF
--- a/docs/algorithms.md
+++ b/docs/algorithms.md
@@ -260,8 +260,8 @@ function ExtractSelectionSet(ctx, insertionPoint, parentType, selectionSet, loca
             append childrenSteps to the result's query plan steps
         }
     }
-    if parentType is a boundary type and the result selectionSet doesn't have an "id" field {
-        add the "id" field to the result selectionSet, aliased to "_id"
+    if parentType is a boundary type {
+        add the "id" field to the result selectionSet, aliased as "__id"
     }
     return result :: (ast.SelectionSet, []QueryPlanStep)
 }

--- a/execution_test.go
+++ b/execution_test.go
@@ -1243,7 +1243,7 @@ func TestQueryWithArrayBoundaryFieldsAndMultipleChildrenSteps(t *testing.T) {
 						"data": {
 							"_result": [
 								{
-									"_id": "1",
+									"__id": "1",
 									"compTitles": [
 										{"id": "2"},
 										{"id": "3"},
@@ -1348,7 +1348,7 @@ func TestQueryWithBoundaryFieldsAndNullsAboveInsertionPoint(t *testing.T) {
 					w.Write([]byte(`{
 							"data": {
 								"_0": {
-									"_id": "DIRECTOR1",
+									"__id": "DIRECTOR1",
 									"name": "David Fincher"
 								}
 							}
@@ -1399,7 +1399,7 @@ func TestExtractBoundaryIDs(t *testing.T) {
 				"id": "1",
 				"name": "Gizmo 1",
 				"owner": {
-					"_id": "1"
+					"__id": "1"
 				}
 			},
 			{
@@ -1413,7 +1413,7 @@ func TestExtractBoundaryIDs(t *testing.T) {
 				"id": "3",
 				"name": "Gizmo 3",
 				"owner": {
-					"_id": "2"
+					"__id": "2"
 				}
 			},
 			{
@@ -1440,7 +1440,7 @@ func TestTrimInsertionPointForNestedBoundaryQuery(t *testing.T) {
 				"id": "1",
 				"name": "Gizmo 1",
 				"owner": {
-					"_id": "1"
+					"__id": "1"
 				}
 			},
 			{
@@ -1454,7 +1454,7 @@ func TestTrimInsertionPointForNestedBoundaryQuery(t *testing.T) {
 				"id": "3",
 				"name": "Gizmo 3",
 				"owner": {
-					"_id": "2"
+					"__id": "2"
 				}
 			},
 			{
@@ -1495,7 +1495,7 @@ func TestBuildBoundaryQueryDocuments(t *testing.T) {
 	ids := []string{"1", "2", "3"}
 	selectionSet := []ast.Selection{
 		&ast.Field{
-			Alias:            "_id",
+			Alias:            "__id",
 			Name:             "id",
 			Definition:       schema.Types["Owner"].Fields.ForName("id"),
 			ObjectDefinition: schema.Types["Owner"],
@@ -1515,7 +1515,7 @@ func TestBuildBoundaryQueryDocuments(t *testing.T) {
 		InsertionPoint: []string{"gizmos", "owner"},
 		Then:           nil,
 	}
-	expected := []string{`{ _result: getOwners(ids: ["1", "2", "3"]) { _id: id name } }`}
+	expected := []string{`{ _result: getOwners(ids: ["1", "2", "3"]) { __id: id name } }`}
 	ctx := testContextWithoutVariables(nil)
 	docs, err := buildBoundaryQueryDocuments(ctx, schema, step, ids, boundaryField, 1)
 	require.NoError(t, err)
@@ -1545,7 +1545,7 @@ func TestBuildNonArrayBoundaryQueryDocuments(t *testing.T) {
 	ids := []string{"1", "2", "3"}
 	selectionSet := []ast.Selection{
 		&ast.Field{
-			Alias:            "_id",
+			Alias:            "__id",
 			Name:             "id",
 			Definition:       schema.Types["Owner"].Fields.ForName("id"),
 			ObjectDefinition: schema.Types["Owner"],
@@ -1565,7 +1565,7 @@ func TestBuildNonArrayBoundaryQueryDocuments(t *testing.T) {
 		InsertionPoint: []string{"gizmos", "owner"},
 		Then:           nil,
 	}
-	expected := []string{`{ _0: getOwner(id: "1") { _id: id name } _1: getOwner(id: "2") { _id: id name } _2: getOwner(id: "3") { _id: id name } }`}
+	expected := []string{`{ _0: getOwner(id: "1") { __id: id name } _1: getOwner(id: "2") { __id: id name } _2: getOwner(id: "3") { __id: id name } }`}
 	ctx := testContextWithoutVariables(nil)
 	docs, err := buildBoundaryQueryDocuments(ctx, schema, step, ids, boundaryField, 10)
 	require.NoError(t, err)
@@ -1595,7 +1595,7 @@ func TestBuildBatchedNonArrayBoundaryQueryDocuments(t *testing.T) {
 	ids := []string{"1", "2", "3"}
 	selectionSet := []ast.Selection{
 		&ast.Field{
-			Alias:            "_id",
+			Alias:            "__id",
 			Name:             "id",
 			Definition:       schema.Types["Owner"].Fields.ForName("id"),
 			ObjectDefinition: schema.Types["Owner"],
@@ -1615,7 +1615,7 @@ func TestBuildBatchedNonArrayBoundaryQueryDocuments(t *testing.T) {
 		InsertionPoint: []string{"gizmos", "owner"},
 		Then:           nil,
 	}
-	expected := []string{`{ _0: getOwner(id: "1") { _id: id name } _1: getOwner(id: "2") { _id: id name } }`, `{ _2: getOwner(id: "3") { _id: id name } }`}
+	expected := []string{`{ _0: getOwner(id: "1") { __id: id name } _1: getOwner(id: "2") { __id: id name } }`, `{ _2: getOwner(id: "3") { __id: id name } }`}
 	ctx := testContextWithoutVariables(nil)
 	docs, err := buildBoundaryQueryDocuments(ctx, schema, step, ids, boundaryField, 2)
 	require.NoError(t, err)
@@ -1815,7 +1815,7 @@ func TestMergeExecutionResults(t *testing.T) {
 				"id": "1",
 				"color": "Gizmo A",
 				"owner": {
-					"_id": "1"
+					"__id": "1"
 				}
 			}
 		}`)
@@ -1828,7 +1828,7 @@ func TestMergeExecutionResults(t *testing.T) {
 
 		inputSliceB := jsonToInterfaceSlice(`[
 			{
-				"_id": "1",
+				"__id": "1",
 				"name": "Owner A"
 			}
 		]`)
@@ -1846,7 +1846,7 @@ func TestMergeExecutionResults(t *testing.T) {
 				"id": "1",
 				"color": "Gizmo A",
 				"owner": {
-					"_id": "1",
+					"__id": "1",
 					"name": "Owner A"
 				}
 			}
@@ -1863,21 +1863,21 @@ func TestMergeExecutionResults(t *testing.T) {
 					"id": "1",
 					"color": "RED",
 					"owner": {
-						"_id": "4"
+						"__id": "4"
 					}
 				},
 				{
 					"id": "2",
 					"color": "GREEN",
 					"owner": {
-						"_id": "5"
+						"__id": "5"
 					}
 				},
 				{
 					"id": "3",
 					"color": "BLUE",
 					"owner": {
-						"_id": "6"
+						"__id": "6"
 					}
 				}
 			]
@@ -1891,15 +1891,15 @@ func TestMergeExecutionResults(t *testing.T) {
 
 		inputSliceB := jsonToInterfaceSlice(`[
 			{
-				"_id": "4",
+				"__id": "4",
 				"name": "Owner A"
 			},
 			{
-				"_id": "5",
+				"__id": "5",
 				"name": "Owner B"
 			},
 			{
-				"_id": "6",
+				"__id": "6",
 				"name": "Owner C"
 			}
 		]`)
@@ -1918,7 +1918,7 @@ func TestMergeExecutionResults(t *testing.T) {
 					"id": "1",
 					"color": "RED",
 					"owner": {
-						"_id": "4",
+						"__id": "4",
 						"name": "Owner A"
 					}
 				},
@@ -1926,7 +1926,7 @@ func TestMergeExecutionResults(t *testing.T) {
 					"id": "2",
 					"color": "GREEN",
 					"owner": {
-						"_id": "5",
+						"__id": "5",
 						"name": "Owner B"
 					}
 				},
@@ -1934,7 +1934,7 @@ func TestMergeExecutionResults(t *testing.T) {
 					"id": "3",
 					"color": "BLUE",
 					"owner": {
-						"_id": "6",
+						"__id": "6",
 						"name": "Owner C"
 					}
 				}
@@ -1952,21 +1952,21 @@ func TestMergeExecutionResults(t *testing.T) {
 					"id": "1",
 					"color": "RED",
 					"owner": {
-						"_id": "4"
+						"__id": "4"
 					}
 				},
 				{
 					"id": "2",
 					"color": "GREEN",
 					"owner": {
-						"_id": "5"
+						"__id": "5"
 					}
 				},
 				{
 					"id": "3",
 					"color": "BLUE",
 					"owner": {
-						"_id": "6"
+						"__id": "6"
 					}
 				}
 			]
@@ -1980,15 +1980,15 @@ func TestMergeExecutionResults(t *testing.T) {
 
 		inputSliceB := jsonToInterfaceSlice(`[
 			{
-				"_id": "4",
+				"__id": "4",
 				"name": "Owner A"
 			},
 			{
-				"_id": "5",
+				"__id": "5",
 				"name": "Owner B"
 			},
 			{
-				"_id": "6",
+				"__id": "6",
 				"name": "Owner C"
 			}
 		]`)
@@ -2007,7 +2007,7 @@ func TestMergeExecutionResults(t *testing.T) {
 					"id": "1",
 					"color": "RED",
 					"owner": {
-						"_id": "4",
+						"__id": "4",
 						"name": "Owner A"
 					}
 				},
@@ -2015,7 +2015,7 @@ func TestMergeExecutionResults(t *testing.T) {
 					"id": "2",
 					"color": "GREEN",
 					"owner": {
-						"_id": "5",
+						"__id": "5",
 						"name": "Owner B"
 					}
 				},
@@ -2023,7 +2023,7 @@ func TestMergeExecutionResults(t *testing.T) {
 					"id": "3",
 					"color": "BLUE",
 					"owner": {
-						"_id": "6",
+						"__id": "6",
 						"name": "Owner C"
 					}
 				}
@@ -2034,7 +2034,7 @@ func TestMergeExecutionResults(t *testing.T) {
 		require.Equal(t, expected, mergedMap)
 	})
 
-	t.Run("allows using both 'id' and '_id'", func(t *testing.T) {
+	t.Run("allows using both 'id' and '__id'", func(t *testing.T) {
 		inputMapA := jsonToInterfaceMap(`{
 			"gizmos": [
 				{
@@ -2055,7 +2055,7 @@ func TestMergeExecutionResults(t *testing.T) {
 					"id": "3",
 					"color": "BLUE",
 					"owner": {
-						"_id": "6"
+						"__id": "6"
 					}
 				}
 			]
@@ -2069,7 +2069,7 @@ func TestMergeExecutionResults(t *testing.T) {
 
 		inputSliceB := jsonToInterfaceSlice(`[
 			{
-				"_id": "4",
+				"__id": "4",
 				"name": "Owner A"
 			},
 			{
@@ -2112,7 +2112,7 @@ func TestMergeExecutionResults(t *testing.T) {
 					"id": "3",
 					"color": "BLUE",
 					"owner": {
-						"_id": "6",
+						"__id": "6",
 						"name": "Owner C"
 					}
 				}
@@ -4591,7 +4591,7 @@ func TestMutationExecution(t *testing.T) {
 				handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					var q map[string]string
 					json.NewDecoder(r.Body).Decode(&q)
-					assertQueriesEqual(t, schema1, `mutation { updateTitle(id: "2", title: "New title") { _id: id title } }`, q["query"])
+					assertQueriesEqual(t, schema1, `mutation { updateTitle(id: "2", title: "New title") { __id: id title } }`, q["query"])
 
 					w.Write([]byte(`{
 						"data": {
@@ -4682,7 +4682,7 @@ func TestQueryExecutionWithUnions(t *testing.T) {
 						w.Write([]byte(`{
 							"data": {
 								"_0": {
-									"_id": "2",
+									"__id": "2",
 									"pet": {
 										"name": "felix",
 										"age": 2,
@@ -4711,7 +4711,7 @@ func TestQueryExecutionWithUnions(t *testing.T) {
 					w.Write([]byte(`{
 						"data": {
 							"person": {
-								"_id": "2",
+								"__id": "2",
 								"name": "Bob"
 							}
 						}
@@ -4787,7 +4787,7 @@ func TestQueryExecutionWithNamespaces(t *testing.T) {
 						w.Write([]byte(`{
 							"data": {
 								"_0": {
-									"_id": "CA7",
+									"__id": "CA7",
 									"name": "Felix"
 								}
 							}

--- a/plan_test.go
+++ b/plan_test.go
@@ -35,7 +35,7 @@ func TestQueryPlanAB1(t *testing.T) {
 			  {
 				"ServiceURL": "B",
 				"ParentType": "Movie",
-				"SelectionSet": "{ _id: id compTitles(limit: 42) { id } }",
+				"SelectionSet": "{ __id: id compTitles(limit: 42) { id } }",
 				"InsertionPoint": ["movies"],
 				"Then": null
 			  }
@@ -59,7 +59,7 @@ func TestQueryPlanAB2(t *testing.T) {
 			  {
 				"ServiceURL": "B",
 				"ParentType": "Movie",
-				"SelectionSet": "{ _id: id compTitles(limit: 42) { id compTitles(limit: 666) { id } } }",
+				"SelectionSet": "{ __id: id compTitles(limit: 42) { id compTitles(limit: 666) { id } } }",
 				"InsertionPoint": ["movies"],
 				"Then": null
 			  }
@@ -83,13 +83,13 @@ func TestQueryPlanABA1(t *testing.T) {
 			  {
 				"ServiceURL": "B",
 				"ParentType": "Movie",
-				"SelectionSet": "{ _id: id compTitles(limit: 42) { id } }",
+				"SelectionSet": "{ __id: id compTitles(limit: 42) { id } }",
 				"InsertionPoint": ["movies"],
 				"Then": [
 				  {
 					"ServiceURL": "A",
 					"ParentType": "Movie",
-					"SelectionSet": "{ _id: id title }",
+					"SelectionSet": "{ __id: id title }",
 					"InsertionPoint": ["movies", "compTitles"],
 					"Then": null
 				  }
@@ -115,20 +115,20 @@ func TestQueryPlanABA2(t *testing.T) {
 			  {
 				"ServiceURL": "B",
 				"ParentType": "Movie",
-				"SelectionSet": "{ _id: id compTitles(limit: 42) { id compTitles(limit: 666) { id } } }",
+				"SelectionSet": "{ __id: id compTitles(limit: 42) { id compTitles(limit: 666) { id } } }",
 				"InsertionPoint": ["movies"],
 				"Then": [
 				  {
 					"ServiceURL": "A",
 					"ParentType": "Movie",
-					"SelectionSet": "{ _id: id title }",
+					"SelectionSet": "{ __id: id title }",
 					"InsertionPoint": ["movies", "compTitles", "compTitles"],
 					"Then": null
 				  },
 				  {
 					"ServiceURL": "A",
 					"ParentType": "Movie",
-					"SelectionSet": "{ _id: id title }",
+					"SelectionSet": "{ __id: id title }",
 					"InsertionPoint": ["movies", "compTitles"],
 					"Then": null
 				  }
@@ -171,13 +171,13 @@ func TestQueryPlanWithAliases(t *testing.T) {
 		  {
 			"ServiceURL": "A",
 			"ParentType": "Query",
-			"SelectionSet": "{ a1: movies { a2: id a3: title } }",
+			"SelectionSet": "{ a1: movies { __id: id a2: id a3: title } }",
 			"InsertionPoint": null,
 			"Then": [
 			  {
 				"ServiceURL": "B",
 				"ParentType": "Movie",
-				"SelectionSet": "{ _id: id a4: compTitles(limit: 42) { a5: id } }",
+				"SelectionSet": "{ __id: id a4: compTitles(limit: 42) { __id: id a5: id } }",
 				"InsertionPoint": ["a1"],
 				"Then": null
 			  }
@@ -314,13 +314,13 @@ func TestQueryPlanInlineFragmentPlan(t *testing.T) {
 			{
 				"ServiceURL": "A",
 				"ParentType": "Query",
-				"SelectionSet": "{ movies { _id: id ... on Movie { id title(language: French) __typename } } }",
+				"SelectionSet": "{ movies { __id: id ... on Movie { id title(language: French) __typename } } }",
 				"InsertionPoint": null,
 				"Then": [
 					{
 						"ServiceURL": "B",
 						"ParentType": "Movie",
-						"SelectionSet": "{ _id: id compTitles(limit: 42) { id } }",
+						"SelectionSet": "{ __id: id compTitles(limit: 42) { id } }",
 						"InsertionPoint": ["movies"],
 						"Then": null
 					}
@@ -426,19 +426,19 @@ func TestQueryPlanCompleteDeepTraversal(t *testing.T) {
 			{
 				"ServiceURL": "A",
 				"ParentType": "Query",
-				"SelectionSet": "{ shop1 { name products { _id: id } } }",
+				"SelectionSet": "{ shop1 { name products { __id: id } } }",
 				"InsertionPoint": null,
 				"Then": [
 					{
 					"ServiceURL": "B",
 					"ParentType": "Product",
-					"SelectionSet": "{ _id: id name collection { _id: id } }",
+					"SelectionSet": "{ __id: id name collection { __id: id } }",
 					"InsertionPoint": ["shop1", "products"],
 					"Then": [
 							{
 							"ServiceURL": "C",
 							"ParentType": "Collection",
-							"SelectionSet": "{ _id: id name }",
+							"SelectionSet": "{ __id: id name }",
 							"InsertionPoint": ["shop1", "products", "collection"],
 							"Then": null
 							}
@@ -468,13 +468,13 @@ func TestQueryPlanMergeInsertionPointSteps(t *testing.T) {
 			{
 				"ServiceURL": "A",
 				"ParentType": "Query",
-				"SelectionSet": "{ shop1 { products { _id: id } products { _id: id } } }",
+				"SelectionSet": "{ shop1 { products { __id: id } products { __id: id } } }",
 				"InsertionPoint": null,
 				"Then": [
 					{
 					"ServiceURL": "B",
 					"ParentType": "Product",
-					"SelectionSet": "{ _id: id name _id: id name }",
+					"SelectionSet": "{ __id: id name __id: id name }",
 					"InsertionPoint": ["shop1", "products"],
 					"Then": null
 					}
@@ -494,8 +494,8 @@ func TestQueryPlanExpandAbstractTypesWithPossibleBoundaryIds(t *testing.T) {
 	}`
 	rootFieldSelections := []string{
 		"name",
-		"... on Lion { _id: id }",
-		"... on Snake { _id: id }",
+		"... on Lion { __id: id }",
+		"... on Snake { __id: id }",
 	}
 	PlanTestFixture3.CheckUnorderedRootFieldSelections(t, query, rootFieldSelections)
 }
@@ -515,10 +515,10 @@ func TestQueryPlanInlineFragmentSpreadOfInterface(t *testing.T) {
 	}`
 	rootFieldSelections := []string{
 		"name",
-		"... on Lion { _id: id }",
-		"... on Snake { _id: id }",
+		"... on Lion { __id: id }",
+		"... on Snake { __id: id }",
 		"... on Lion { maneColor __typename }",
-		"... on Snake { _id: id __typename }",
+		"... on Snake { __id: id __typename }",
 	}
 	PlanTestFixture3.CheckUnorderedRootFieldSelections(t, query, rootFieldSelections)
 }
@@ -584,7 +584,7 @@ func TestQueryPlanSkipAndIncludeDirectiveInChildStep(t *testing.T) {
 			  {
 				"ServiceURL": "B",
 				"ParentType": "Movie",
-				"SelectionSet": "{ _id: id compTitles(limit: 42) { id @skip(if: false) @include(if: true) } }",
+				"SelectionSet": "{ __id: id compTitles(limit: 42) { id @skip(if: false) @include(if: true) } }",
 				"InsertionPoint": ["movies"],
 				"Then": null
 			  }
@@ -608,7 +608,7 @@ func TestQueryPlanSupportsAliasing(t *testing.T) {
             {
               "ServiceURL": "B",
               "ParentType": "Movie",
-              "SelectionSet": "{ _id: id bar: compTitles(limit: 42) { id } }",
+              "SelectionSet": "{ __id: id bar: compTitles(limit: 42) { id } }",
               "InsertionPoint": [
                 "foo"
               ],
@@ -616,7 +616,7 @@ func TestQueryPlanSupportsAliasing(t *testing.T) {
                 {
                   "ServiceURL": "A",
                   "ParentType": "Movie",
-                  "SelectionSet": "{ _id: id compTitleAliasTitle: title }",
+                  "SelectionSet": "{ __id: id compTitleAliasTitle: title }",
                   "InsertionPoint": [
                     "foo",
                     "bar"
@@ -686,13 +686,13 @@ func TestQueryPlanSupportsMutations(t *testing.T) {
 		  {
 			"ServiceURL": "A",
 			"ParentType": "Mutation",
-			"SelectionSet": "{ updateTitle(id: \"2\", title: \"New title\") { _id: id title } }",
+			"SelectionSet": "{ updateTitle(id: \"2\", title: \"New title\") { __id: id title } }",
 			"InsertionPoint": null,
 			"Then": [
 			  {
 				"ServiceURL": "B",
 				"ParentType": "Movie",
-				"SelectionSet": "{ _id: id release }",
+				"SelectionSet": "{ __id: id release }",
 				"InsertionPoint": [
 				  "updateTitle"
 				],
@@ -718,7 +718,7 @@ func TestQueryPlanWithPaginatedBoundaryType(t *testing.T) {
 			{
 				"ServiceURL": "B",
 				"ParentType": "Foo",
-				"SelectionSet": "{ _id: id size }",
+				"SelectionSet": "{ __id: id size }",
 				"InsertionPoint": [ "foo", "foos", "page" ],
 				"Then": null
 			}
@@ -811,7 +811,7 @@ func TestQueryPlanWithNestedNamespaces(t *testing.T) {
 			  {
 				"ServiceURL": "B",
 				"ParentType": "CompTitle",
-				"SelectionSet": "{ _id: id score }",
+				"SelectionSet": "{ __id: id score }",
 				"InsertionPoint": [
 				  "firstLevel",
 				  "secondLevel",
@@ -851,4 +851,12 @@ func TestQueryPlanNoUnnessecaryID(t *testing.T) {
 		]
 	  }
 	`)
+}
+
+func TestQueryPlanValidateReservedIdAlias(t *testing.T) {
+	PlanTestFixture1.CheckError(t, "{ movies { __id: title } }")
+}
+
+func TestQueryPlanValidateReservedTypenameAlias(t *testing.T) {
+	PlanTestFixture1.CheckError(t, "{ movies { __typename: title } }")
 }

--- a/query_execution.go
+++ b/query_execution.go
@@ -283,10 +283,10 @@ func (q *queryExecution) createGQLErrors(step *QueryPlanStep, err error) gqlerro
 // crawling for ids:
 // [
 // 	 {
-//     "_id": "MOVIE1",
+//     "__id": "MOVIE1",
 //     "compTitles": [
 //       {
-//   	   "_id": "1"
+//   	   "__id": "1"
 // 		 }
 //	   ]
 //   }
@@ -520,7 +520,7 @@ func mergeExecutionResultsRec(src interface{}, dst interface{}, insertionPoint [
 					}
 					if srcID == dstID {
 						for k, v := range result {
-							if k == "_id" || k == "id" {
+							if k == "__id" || k == "id" {
 								continue
 							}
 
@@ -570,7 +570,7 @@ func mergeExecutionResultsRec(src interface{}, dst interface{}, insertionPoint [
 }
 
 func boundaryIDFromMap(boundaryMap map[string]interface{}) (string, error) {
-	id, ok := boundaryMap["_id"].(string)
+	id, ok := boundaryMap["__id"].(string)
 	if ok {
 		return id, nil
 	}
@@ -578,7 +578,7 @@ func boundaryIDFromMap(boundaryMap map[string]interface{}) (string, error) {
 	if ok {
 		return id, nil
 	}
-	return "", errors.New("boundaryIDFromMap: 'id' or '_id' not found")
+	return "", errors.New("boundaryIDFromMap: \"__id\" or \"id\" not found")
 }
 
 func getBoundaryFieldResults(src []interface{}) ([]map[string]interface{}, error) {


### PR DESCRIPTION
Imposes validation errors around the use of `__id` and `__typename` aliases to prevent user-sabotaged query errors, as discussed in https://github.com/movio/bramble/issues/90.

## The Problem

Per https://github.com/movio/bramble/issues/90, there were lots of ways to hoodwink `id` and `__typename` selection hints into breaking a query, for example:

```graphql
query {
  shop1 {
    products {
      boo: id
      name
    }
  }
}
```

The permissiveness of GraphQL aliases allows a user to hijack federation implementation details.

## The Fix

This adds validation errors to restrict the use of `__id` and `__typename` field aliases for non-standard purposes. In this process, `_id` becomes `__id` to align with the double-underscore convention of GraphQL internals.

Resolves https://github.com/movio/bramble/issues/90