### PR TITLE
Fix issue with schema getting out of sync after service error

### DIFF
--- a/execution.go
+++ b/execution.go
@@ -85,6 +85,7 @@ func (s *ExecutableSchema) UpdateSchema(forceRebuild bool) error {
 		if err != nil {
 			promServiceUpdateError.WithLabelValues(s.ServiceURL).Inc()
 			invalidschema = 1
+			forceRebuild = true
 			logger.WithError(err).Error("unable to update service")
 			// Ignore this service in this update
 			continue

--- a/execution.go
+++ b/execution.go
@@ -69,9 +69,9 @@ func (s *ExecutableSchema) UpdateSchema(forceRebuild bool) error {
 	var services []*Service
 	var schemas []*ast.Schema
 	var updatedServices []string
-	var invalidschema float64 = 0
+	var invalidSchema float64 = 0
 
-	defer func() { promInvalidSchema.Set(invalidschema) }()
+	defer func() { promInvalidSchema.Set(invalidSchema) }()
 
 	promServiceUpdateError.Reset()
 
@@ -84,7 +84,7 @@ func (s *ExecutableSchema) UpdateSchema(forceRebuild bool) error {
 		updated, err := s.Update()
 		if err != nil {
 			promServiceUpdateError.WithLabelValues(s.ServiceURL).Inc()
-			invalidschema = 1
+			invalidSchema = 1
 			forceRebuild = true
 			logger.WithError(err).Error("unable to update service")
 			// Ignore this service in this update
@@ -104,7 +104,7 @@ func (s *ExecutableSchema) UpdateSchema(forceRebuild bool) error {
 		log.Info("rebuilding merged schema")
 		schema, err := MergeSchemas(schemas...)
 		if err != nil {
-			invalidschema = 1
+			invalidSchema = 1
 			return fmt.Errorf("update of service %v caused schema error: %w", updatedServices, err)
 		}
 

--- a/introspection.go
+++ b/introspection.go
@@ -41,6 +41,7 @@ func (s *Service) Update() (bool, error) {
 	}{}
 
 	if err := s.client.Request(context.Background(), s.ServiceURL, req, &response); err != nil {
+		s.SchemaSource = ""
 		s.Status = "Unreachable"
 		return false, err
 	}


### PR DESCRIPTION
## The Problem

As a part of normal operation, Bramble periodically polls its known services to fetch their latest schemas and update its own merged schema. Movio runs everything in k8s where services come and go frequently, however we'd been noticing occasional issues where the merged schema wasn't an accurate representation of the current available services. It turns out this was due to a couple of bugs in the handling of errors while refreshing service schemas.

The problem could manifest in two ways: 

**Services that are currently available are not able to be queried**

* Service A is available and queryable
* Service A goes down
* No other has changed and so merged schema is not rebuilt
* Service A is unavailable but still a part of the merged schema

**Services that have gone down and come back are not queryable**

* Service A is available and queryable
* Service A goes down
* While Service A is down, the schema is rebuilt due to another service changing
* Service A is now removed from the merged schema
* Service A comes back but is still not added to the merged schema. This is due to the Service struct still holding onto the same schema from before Service A went down. The code does not detect a schema change for Service A and so service A remains out of the schema until something else triggers a schema rebuild.

## The Fix

If a service goes down, force a rebuild of the merged schema to make sure it's immediately excluded . Also make sure the schema on the Service struct is always invalidated when hitting an error, this means when the service comes back a schema rebuild will be triggered.

There were some changes required to modify the existing execution test fixture to allow the testing of the schema update behaviour.
