### PR TITLE
Use `_bramble__typename` alias for bramble injected __typename 

### DIFF
--- a/execution_test.go
+++ b/execution_test.go
@@ -602,7 +602,7 @@ func TestFederatedQueryFragmentSpreads(t *testing.T) {
 							"id": "100",
 							"name": "foo",
 							"gizmos": [{ "_bramble_id": "GIZMO1", "id": "GIZMO1" }],
-							"__typename": "GizmoImplementation"
+							"_bramble__typename": "GizmoImplementation"
 						}
 					}
 				}`))
@@ -614,7 +614,7 @@ func TestFederatedQueryFragmentSpreads(t *testing.T) {
 							"id": "100",
 							"name": "foo",
 							"gadgets": [{ "_bramble_id": "GADGET1", "id": "GADGET1" }],
-							"__typename": "GadgetImplementation"
+							"_bramble__typename": "GadgetImplementation"
 						}
 					}
 				}`))
@@ -672,7 +672,7 @@ func TestFederatedQueryFragmentSpreads(t *testing.T) {
 									{
 										"name": "James Bond",
 										"country": "UK",
-										"__typename": "Agent"
+										"_bramble__typename": "Agent"
 									}
 								]
 							}
@@ -1055,7 +1055,7 @@ func TestQueryExecutionNamespaceAndFragmentSpread(t *testing.T) {
 									"movies": [
 										{"title": "The Big Blue"}
 									],
-									"__typename": "Director"
+									"_bramble__typename": "Director"
 								}
 							}
 						}
@@ -2803,9 +2803,9 @@ func TestBubbleUpNullValuesInPlace(t *testing.T) {
 
 		resultJSON := `{
 			"gizmos": [
-				{ "id": "GIZMO1", "color": "RED", "__typename": "Gizmo" },
-				{ "id": "GIZMO2", "color": "GREEN", "__typename": "Gizmo" },
-				{ "id": "GIZMO3", "color": null, "__typename": "Gizmo" }
+				{ "id": "GIZMO1", "color": "RED", "_bramble__typename": "Gizmo" },
+				{ "id": "GIZMO2", "color": "GREEN", "_bramble__typename": "Gizmo" },
+				{ "id": "GIZMO3", "color": null, "_bramble__typename": "Gizmo" }
 			]
 		}`
 
@@ -2836,7 +2836,7 @@ func TestBubbleUpNullValuesInPlace(t *testing.T) {
 				Path:       ast.Path{ast.PathName("gizmos"), ast.PathIndex(2), ast.PathName("color")},
 				Extensions: nil,
 			}}), errs)
-		require.Equal(t, jsonToInterfaceMap(`{ "gizmos": [ { "id": "GIZMO1", "color": "RED", "__typename": "Gizmo" }, { "id": "GIZMO2", "color": "GREEN", "__typename": "Gizmo" }, null ]	}`), result)
+		require.Equal(t, jsonToInterfaceMap(`{ "gizmos": [ { "id": "GIZMO1", "color": "RED", "_bramble__typename": "Gizmo" }, { "id": "GIZMO2", "color": "GREEN", "_bramble__typename": "Gizmo" }, null ]	}`), result)
 	})
 
 	t.Run("works with inline fragments", func(t *testing.T) {
@@ -2859,9 +2859,9 @@ func TestBubbleUpNullValuesInPlace(t *testing.T) {
 
 		resultJSON := `{
 			"gizmos": [
-				{ "id": "GIZMO1", "color": "RED", "__typename": "Gizmo" },
-				{ "id": "GIZMO2", "color": "GREEN", "__typename": "Gizmo" },
-				{ "id": "GIZMO3", "color": null, "__typename": "Gizmo" }
+				{ "id": "GIZMO1", "color": "RED", "_bramble__typename": "Gizmo" },
+				{ "id": "GIZMO2", "color": "GREEN", "_bramble__typename": "Gizmo" },
+				{ "id": "GIZMO3", "color": null, "_bramble__typename": "Gizmo" }
 			]
 		}`
 
@@ -2889,7 +2889,7 @@ func TestBubbleUpNullValuesInPlace(t *testing.T) {
 				Path:       ast.Path{ast.PathName("gizmos"), ast.PathIndex(2), ast.PathName("color")},
 				Extensions: nil,
 			}}), errs)
-		require.Equal(t, jsonToInterfaceMap(`{ "gizmos": [ { "id": "GIZMO1", "color": "RED", "__typename": "Gizmo" }, { "id": "GIZMO2", "color": "GREEN", "__typename": "Gizmo" }, null ]	}`), result)
+		require.Equal(t, jsonToInterfaceMap(`{ "gizmos": [ { "id": "GIZMO1", "color": "RED", "_bramble__typename": "Gizmo" }, { "id": "GIZMO2", "color": "GREEN", "_bramble__typename": "Gizmo" }, null ]	}`), result)
 	})
 
 	t.Run("inline fragment inside interface", func(t *testing.T) {
@@ -2914,9 +2914,9 @@ func TestBubbleUpNullValuesInPlace(t *testing.T) {
 
 		resultJSON := `{
 			"critters": [
-				{ "id": "GIZMO1", "color": "RED", "__typename": "Gizmo" },
-				{ "id": "GREMLIN1", "name": "Spikey", "__typename": "Gremlin" },
-				{ "id": "GIZMO2", "color": null, "__typename": "Gizmo" }
+				{ "id": "GIZMO1", "color": "RED", "_bramble__typename": "Gizmo" },
+				{ "id": "GREMLIN1", "name": "Spikey", "_bramble__typename": "Gremlin" },
+				{ "id": "GIZMO2", "color": null, "_bramble__typename": "Gizmo" }
 			]
 		}`
 
@@ -2948,7 +2948,7 @@ func TestBubbleUpNullValuesInPlace(t *testing.T) {
 				Path:       ast.Path{ast.PathName("critters"), ast.PathIndex(2), ast.PathName("color")},
 				Extensions: nil,
 			}}), errs)
-		require.Equal(t, jsonToInterfaceMap(`{ "critters": [ { "id": "GIZMO1", "color": "RED", "__typename": "Gizmo"  }, { "id": "GREMLIN1", "name": "Spikey", "__typename": "Gremlin" }, null ]	}`), result)
+		require.Equal(t, jsonToInterfaceMap(`{ "critters": [ { "id": "GIZMO1", "color": "RED", "_bramble__typename": "Gizmo"  }, { "id": "GREMLIN1", "name": "Spikey", "_bramble__typename": "Gremlin" }, null ]	}`), result)
 	})
 
 	t.Run("fragment spread inside interface", func(t *testing.T) {
@@ -2973,9 +2973,9 @@ func TestBubbleUpNullValuesInPlace(t *testing.T) {
 
 		resultJSON := `{
 			"critters": [
-				{ "id": "GIZMO1", "color": "RED", "__typename": "Gizmo" },
-				{ "id": "GREMLIN1", "name": "Spikey", "__typename": "Gremlin" },
-				{ "id": "GIZMO2", "color": null, "__typename": "Gizmo" }
+				{ "id": "GIZMO1", "color": "RED", "_bramble__typename": "Gizmo" },
+				{ "id": "GREMLIN1", "name": "Spikey", "_bramble__typename": "Gremlin" },
+				{ "id": "GIZMO2", "color": null, "_bramble__typename": "Gizmo" }
 			]
 		}`
 
@@ -3011,7 +3011,7 @@ func TestBubbleUpNullValuesInPlace(t *testing.T) {
 				Path:       ast.Path{ast.PathName("critters"), ast.PathIndex(2), ast.PathName("color")},
 				Extensions: nil,
 			}}), errs)
-		require.Equal(t, jsonToInterfaceMap(`{ "critters": [ { "id": "GIZMO1", "color": "RED", "__typename": "Gizmo"  }, { "id": "GREMLIN1", "name": "Spikey", "__typename": "Gremlin" }, null ]	}`), result)
+		require.Equal(t, jsonToInterfaceMap(`{ "critters": [ { "id": "GIZMO1", "color": "RED", "_bramble__typename": "Gizmo"  }, { "id": "GREMLIN1", "name": "Spikey", "_bramble__typename": "Gremlin" }, null ]	}`), result)
 	})
 }
 
@@ -3216,10 +3216,10 @@ func TestFormatResponseBody(t *testing.T) {
 					"id": "OWNER1",
 					"fullName": "James Bond"
 				},
+				"_bramble__typename": "Gadget",
 				"__typename": "Gadget"
 			}
-		}
-	`)
+		}`)
 
 		schema := gqlparser.MustLoadSchema(&ast.Source{Name: "fixture", Input: ddl})
 
@@ -3290,6 +3290,7 @@ func TestFormatResponseBody(t *testing.T) {
 			"gizmo": {
 				"id": "GADGET1",
 				"name": "Gadget #1",
+				"_bramble__typename": "Gadget",
 				"__typename": "Gadget"
 			}
 		}
@@ -3362,7 +3363,8 @@ func TestFormatResponseBody(t *testing.T) {
 			"gizmo": {
 				"id": "GADGET1",
 				"name": "Gadget #1",
-				"__typename": "Gadget"
+				"__typename": "Gadget",
+				"_bramble__typename": "Gadget"
 			}
 		}
 	`)
@@ -3438,6 +3440,7 @@ func TestFormatResponseBody(t *testing.T) {
 				"id": "TOOL1",
 				"name": "Tool #1",
 				"category": "Screwdriver",
+				"_bramble__typename": "Tool",
 				"__typename": "Tool"
 			}
 		}
@@ -4715,9 +4718,9 @@ func TestQueryExecutionWithUnions(t *testing.T) {
 						w.Write([]byte(`{
 							"data": {
 								"foo": [
-									{ "name": "fido", "age": 4, "__typename": "Dog" },
-									{ "name": "felix", "age": 2, "__typename": "Cat" },
-									{ "age": 20, "name": "ka", "__typename": "Snake" }
+									{ "name": "fido", "age": 4, "_bramble__typename": "Dog" },
+									{ "name": "felix", "age": 2, "_bramble__typename": "Cat" },
+									{ "age": 20, "name": "ka", "_bramble__typename": "Snake" }
 								]
 							}
 						}
@@ -4730,7 +4733,7 @@ func TestQueryExecutionWithUnions(t *testing.T) {
 									"pet": {
 										"name": "felix",
 										"age": 2,
-										"__typename": "Cat"
+										"_bramble__typename": "Cat"
 									}
 								}
 							}

--- a/plan.go
+++ b/plan.go
@@ -117,8 +117,8 @@ func createSteps(ctx *PlanningContext, insertionPoint []string, parentType strin
 }
 
 var reservedAliases = map[string]string{
-	"__typename":  "__typename",
-	"_bramble_id": "id",
+	"_bramble__typename": "__typename",
+	"_bramble_id":        "id",
 }
 
 func extractSelectionSet(ctx *PlanningContext, insertionPoint []string, parentType string, input ast.SelectionSet, location string) (ast.SelectionSet, []*QueryPlanStep, error) {
@@ -183,7 +183,7 @@ func extractSelectionSet(ctx *PlanningContext, insertionPoint []string, parentTy
 			if err != nil {
 				return nil, nil, err
 			}
-			selectionSet = append(selectionSet, &ast.Field{Alias: "__typename", Name: "__typename", Definition: &ast.FieldDefinition{Name: "__typename", Type: ast.NamedType("String", nil)}})
+			selectionSet = append(selectionSet, &ast.Field{Alias: "_bramble__typename", Name: "__typename", Definition: &ast.FieldDefinition{Name: "__typename", Type: ast.NamedType("String", nil)}})
 			inlineFragment := *selection
 			inlineFragment.SelectionSet = selectionSet
 			selectionSetResult = append(selectionSetResult, &inlineFragment)
@@ -199,7 +199,7 @@ func extractSelectionSet(ctx *PlanningContext, insertionPoint []string, parentTy
 			if err != nil {
 				return nil, nil, err
 			}
-			selectionSet = append(selectionSet, &ast.Field{Alias: "__typename", Name: "__typename", Definition: &ast.FieldDefinition{Name: "__typename", Type: ast.NamedType("String", nil)}})
+			selectionSet = append(selectionSet, &ast.Field{Alias: "_bramble__typename", Name: "__typename", Definition: &ast.FieldDefinition{Name: "__typename", Type: ast.NamedType("String", nil)}})
 			inlineFragment := ast.InlineFragment{
 				TypeCondition: selection.Definition.TypeCondition,
 				SelectionSet:  selectionSet,
@@ -264,7 +264,7 @@ func extractSelectionSet(ctx *PlanningContext, insertionPoint []string, parentTy
 			}
 		}
 		selectionSetResult = append(selectionSetResult, &ast.Field{
-			Alias:      "__typename",
+			Alias:      "_bramble__typename",
 			Name:       "__typename",
 			Definition: &ast.FieldDefinition{Name: "__typename", Type: ast.NamedType("String", nil)},
 		})

--- a/plan_fixtures_test.go
+++ b/plan_fixtures_test.go
@@ -1,18 +1,18 @@
 package bramble
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"sort"
 	"testing"
-	"context"
-	"fmt"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/99designs/gqlgen/graphql"
 	"github.com/vektah/gqlparser/v2"
 	"github.com/vektah/gqlparser/v2/ast"
-	"github.com/99designs/gqlgen/graphql"
 )
 
 type PlanTestFixture struct {
@@ -247,22 +247,21 @@ var PlanTestFixture6 = &PlanTestFixture{
 	}`,
 
 	Locations: map[string]string{
-		"Query.shop1":         "A",
-		"Shop.id":             "A",
-		"Shop.name":           "A",
-		"Shop.products":       "A",
-		"Product.name":        "B",
-		"Product.collection":  "B",
-		"Collection.name":     "C",
+		"Query.shop1":        "A",
+		"Shop.id":            "A",
+		"Shop.name":          "A",
+		"Shop.products":      "A",
+		"Product.name":       "B",
+		"Product.collection": "B",
+		"Collection.name":    "C",
 	},
 
 	IsBoundary: map[string]bool{
-		"Shop":        false,
-		"Product":     true,
-		"Collection":  true,
+		"Shop":       false,
+		"Product":    true,
+		"Collection": true,
 	},
 }
-
 
 func (f *PlanTestFixture) Plan(t *testing.T, query string) (*QueryPlan, error) {
 	t.Helper()
@@ -304,10 +303,10 @@ func (f *PlanTestFixture) CheckUnorderedRootFieldSelections(t *testing.T, query 
 		var foundSelection string
 		expectedSelection = fmt.Sprintf("{ %s }", expectedSelection)
 		for _, selection := range rootField.SelectionSet {
-		    if expectedSelection == formatSelectionSetSingleLine(ctx, nil, []ast.Selection{selection}) {
-		      foundSelection = expectedSelection
-		      break
-		    }
+			if expectedSelection == formatSelectionSetSingleLine(ctx, nil, []ast.Selection{selection}) {
+				foundSelection = expectedSelection
+				break
+			}
 		}
 		assert.Equal(t, expectedSelection, foundSelection)
 	}

--- a/plan_test.go
+++ b/plan_test.go
@@ -264,7 +264,7 @@ func TestQueryPlanInlineFragment(t *testing.T) {
 			{
 				"ServiceURL": "A",
 				"ParentType": "Query",
-				"SelectionSet": "{ movies { ... on Movie { id title(language: French) _bramble_id: id __typename } _bramble_id: id } }",
+				"SelectionSet": "{ movies { ... on Movie { id title(language: French) _bramble_id: id _bramble__typename: __typename } _bramble_id: id } }",
 				"InsertionPoint": null,
 				"Then": null
 			}
@@ -288,7 +288,7 @@ func TestQueryPlanInlineFragmentDoesNotDuplicateTypename(t *testing.T) {
 			{
 				"ServiceURL": "A",
 				"ParentType": "Query",
-				"SelectionSet": "{ movies { ... on Movie { __typename id title(language: French) _bramble_id: id __typename } _bramble_id: id } }",
+				"SelectionSet": "{ movies { ... on Movie { __typename id title(language: French) _bramble_id: id _bramble__typename: __typename } _bramble_id: id } }",
 				"InsertionPoint": null,
 				"Then": null
 			}
@@ -314,7 +314,7 @@ func TestQueryPlanInlineFragmentPlan(t *testing.T) {
 			{
 				"ServiceURL": "A",
 				"ParentType": "Query",
-				"SelectionSet": "{ movies { ... on Movie { id title(language: French) _bramble_id: id __typename } _bramble_id: id } }",
+				"SelectionSet": "{ movies { ... on Movie { id title(language: French) _bramble_id: id _bramble__typename: __typename } _bramble_id: id } }",
 				"InsertionPoint": null,
 				"Then": [
 					{
@@ -347,7 +347,7 @@ func TestQueryPlanFragmentSpread1(t *testing.T) {
 			{
 				"ServiceURL": "A",
 				"ParentType": "Query",
-				"SelectionSet": "{ movies { ... on Movie { id title(language: French) _bramble_id: id __typename } _bramble_id: id } }",
+				"SelectionSet": "{ movies { ... on Movie { id title(language: French) _bramble_id: id _bramble__typename: __typename } _bramble_id: id } }",
 				"InsertionPoint": null,
 				"Then": null
 			}
@@ -470,7 +470,7 @@ func TestQueryPlanExpandAbstractTypesWithPossibleBoundaryIds(t *testing.T) {
 		"name",
 		"... on Lion { _bramble_id: id }",
 		"... on Snake { _bramble_id: id }",
-		"__typename",
+		"_bramble__typename: __typename",
 	}
 	PlanTestFixture3.CheckUnorderedRootFieldSelections(t, query, rootFieldSelections)
 }
@@ -492,9 +492,9 @@ func TestQueryPlanInlineFragmentSpreadOfInterface(t *testing.T) {
 		"name",
 		"... on Lion { _bramble_id: id }",
 		"... on Snake { _bramble_id: id }",
-		"... on Lion { maneColor _bramble_id: id __typename }",
-		"... on Snake { _bramble_id: id __typename }",
-		"__typename",
+		"... on Lion { maneColor _bramble_id: id _bramble__typename: __typename }",
+		"... on Snake { _bramble_id: id _bramble__typename: __typename }",
+		"_bramble__typename: __typename",
 	}
 	PlanTestFixture3.CheckUnorderedRootFieldSelections(t, query, rootFieldSelections)
 }
@@ -614,7 +614,7 @@ func TestQueryPlanSupportsUnions(t *testing.T) {
         {
           "ServiceURL": "A",
           "ParentType": "Query",
-          "SelectionSet": "{ animals { ... on Dog { name __typename } ... on Cat { name __typename } ... on Snake { name __typename } __typename } }",
+          "SelectionSet": "{ animals { ... on Dog { name _bramble__typename: __typename } ... on Cat { name _bramble__typename: __typename } ... on Snake { name _bramble__typename: __typename } _bramble__typename: __typename } }",
           "InsertionPoint": null,
           "Then": null
         }
@@ -834,5 +834,5 @@ func TestQueryPlanValidateReservedIdAlias(t *testing.T) {
 }
 
 func TestQueryPlanValidateReservedTypenameAlias(t *testing.T) {
-	PlanTestFixture1.CheckError(t, "{ movies { __typename: title } }")
+	PlanTestFixture1.CheckError(t, "{ movies { _bramble__typename: title } }")
 }

--- a/query_execution.go
+++ b/query_execution.go
@@ -863,7 +863,7 @@ func unionAndTrimSelectionSetRec(objectTypename string, schema *ast.Schema, sele
 }
 
 func extractAndCastTypenameField(result map[string]interface{}) string {
-	typeNameInterface, ok := result["__typename"]
+	typeNameInterface, ok := result["_bramble__typename"]
 	if !ok {
 		return ""
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -1,0 +1,159 @@
+package bramble
+
+import (
+	"testing"
+
+	"github.com/movio/bramble/testsrv"
+	"github.com/stretchr/testify/require"
+	"github.com/vektah/gqlparser/v2"
+)
+
+func TestFederatedQuery(t *testing.T) {
+	gizmoService := testsrv.NewGizmoService()
+	gadgetService := testsrv.NewGadgetService()
+
+	executableSchema := newExecutableSchema(nil, 10, nil, NewService(gizmoService.URL), NewService(gadgetService.URL))
+
+	require.NoError(t, executableSchema.UpdateSchema(true))
+
+	query := gqlparser.MustLoadQuery(executableSchema.MergedSchema, `{
+		gizmo(id: "GIZMO1") {
+			id
+			name
+		}
+	}`)
+
+	ctx := testContextWithoutVariables(query.Operations[0])
+
+	response := executableSchema.ExecuteQuery(ctx)
+	expectedResponse := `
+	{
+		"gizmo": {
+			"id": "GIZMO1",
+			"name": "Gizmo #1"
+		}
+	}
+	`
+	jsonEqWithOrder(t, expectedResponse, string(response.Data))
+	gizmoService.Close()
+	gadgetService.Close()
+}
+
+func TestFederatedQueryWithMultipleFragmentSpreads(t *testing.T) {
+	gizmoService := testsrv.NewGizmoService()
+	gadgetService := testsrv.NewGadgetService()
+
+	executableSchema := newExecutableSchema(nil, 10, nil, NewService(gizmoService.URL), NewService(gadgetService.URL))
+
+	require.NoError(t, executableSchema.UpdateSchema(true))
+
+	t.Run("first fragment matches", func(t *testing.T) {
+		query := gqlparser.MustLoadQuery(executableSchema.MergedSchema, `{
+			gizmo(id: "GIZMO1") {
+				id
+				name
+				gadget {
+					id
+					name
+					... on Jetpack {
+						range
+					}
+					... on InvisibleCar {
+						cloaked
+					}
+				}
+			}
+		}`)
+
+		ctx := testContextWithoutVariables(query.Operations[0])
+
+		response := executableSchema.ExecuteQuery(ctx)
+		expectedResponse := `
+		{
+			"gizmo": {
+				"id": "GIZMO1",
+				"name": "Gizmo #1",
+				"gadget": {
+					"id": "JETPACK1",
+					"name": "Jetpack #1",
+					"range": "500km"
+				}
+			}
+		}`
+
+		jsonEqWithOrder(t, expectedResponse, string(response.Data))
+	})
+
+	t.Run("second fragment matches", func(t *testing.T) {
+		query := gqlparser.MustLoadQuery(executableSchema.MergedSchema, `{
+			gizmo(id: "GIZMO2") {
+				id
+				name
+				gadget {
+					id
+					name
+					... on Jetpack {
+						range
+					}
+					... on InvisibleCar {
+						cloaked
+					}
+				}
+			}
+		}`)
+
+		ctx := testContextWithoutVariables(query.Operations[0])
+
+		response := executableSchema.ExecuteQuery(ctx)
+		expectedResponse := `
+		{
+			"gizmo": {
+				"id": "GIZMO2",
+				"name": "Gizmo #2",
+				"gadget": {
+					"id": "AM1",
+					"name": "Vanquish",
+					"cloaked": true
+				}
+			}
+		}`
+
+		jsonEqWithOrder(t, expectedResponse, string(response.Data))
+	})
+
+	t.Run("no fragments match", func(t *testing.T) {
+		query := gqlparser.MustLoadQuery(executableSchema.MergedSchema, `{
+			gizmo(id: "GIZMO2") {
+				id
+				name
+				gadget {
+					id
+					name
+					... on Jetpack {
+						range
+					}
+				}
+			}
+		}`)
+
+		ctx := testContextWithoutVariables(query.Operations[0])
+
+		response := executableSchema.ExecuteQuery(ctx)
+		expectedResponse := `
+		{
+			"gizmo": {
+				"id": "GIZMO2",
+				"name": "Gizmo #2",
+				"gadget": {
+					"id": "AM1",
+					"name": "Vanquish"
+				}
+			}
+		}`
+
+		jsonEqWithOrder(t, expectedResponse, string(response.Data))
+	})
+
+	gizmoService.Close()
+	gadgetService.Close()
+}

--- a/testsrv/gadget_test_server.go
+++ b/testsrv/gadget_test_server.go
@@ -1,0 +1,153 @@
+package testsrv
+
+import (
+	"errors"
+	"net/http/httptest"
+
+	"github.com/graph-gophers/graphql-go"
+	"github.com/graph-gophers/graphql-go/relay"
+)
+
+type gizmoWithGadgetResolver struct {
+	IDField string
+	Gadget  *gadgetResolver
+}
+
+func (u gizmoWithGadgetResolver) ID() graphql.ID {
+	return graphql.ID(u.IDField)
+}
+
+type gadgetServiceResolver struct {
+	serviceField service
+}
+
+func (g *gadgetServiceResolver) Service() service {
+	return g.serviceField
+}
+
+func (g *gadgetServiceResolver) BoundaryGizmo(args struct{ ID string }) (*gizmoWithGadgetResolver, error) {
+	gadget, ok := gadgetMap[args.ID]
+	if !ok {
+		return nil, errors.New("gadget not found")
+	}
+	return &gizmoWithGadgetResolver{
+		IDField: args.ID,
+		Gadget:  &gadgetResolver{gadget},
+	}, nil
+}
+
+type gadget interface {
+	ID() graphql.ID
+	Name() string
+}
+
+type gadgetResolver struct {
+	gadget
+}
+
+var gadgetMap = map[string]gadget{
+	"GIZMO1": &jetpack{
+		IDField:    "JETPACK1",
+		NameField:  "Jetpack #1",
+		RangeField: "500km",
+	},
+	"GIZMO2": &invisibleCar{
+		IDField:      "AM1",
+		NameField:    "Vanquish",
+		CloakedField: true,
+	},
+}
+
+type jetpack struct {
+	IDField    string
+	NameField  string
+	RangeField string
+}
+
+func (r *gadgetResolver) ToJetpack() (*jetpack, bool) {
+	jetpack, ok := r.gadget.(*jetpack)
+	return jetpack, ok
+}
+
+func (j jetpack) ID() graphql.ID {
+	return graphql.ID(j.IDField)
+}
+
+func (j jetpack) Name() string {
+	return j.NameField
+}
+
+func (j jetpack) Range() string {
+	return j.RangeField
+}
+
+type invisibleCar struct {
+	IDField      string
+	NameField    string
+	CloakedField bool
+}
+
+func (r *gadgetResolver) ToInvisibleCar() (*invisibleCar, bool) {
+	invisableCar, ok := r.gadget.(*invisibleCar)
+	return invisableCar, ok
+}
+
+func (j invisibleCar) ID() graphql.ID {
+	return graphql.ID(j.IDField)
+}
+
+func (j invisibleCar) Name() string {
+	return j.NameField
+}
+
+func (j invisibleCar) Cloaked() bool {
+	return j.CloakedField
+}
+
+func NewGadgetService() *httptest.Server {
+	s := `
+	directive @boundary on OBJECT | FIELD_DEFINITION
+
+	type Query {
+		service: Service!
+		boundaryGizmo(id: ID!): Gizmo @boundary
+	}
+
+	type Gizmo @boundary {
+		id: ID!
+		gadget: Gadget
+	}
+
+	interface Gadget {
+		id: ID!
+		name: String!
+	}
+
+	type Jetpack implements Gadget {
+		id: ID!
+		name: String!
+		range: String!
+	}
+
+	type InvisibleCar implements Gadget {
+		id: ID!
+		name: String!
+		cloaked: Boolean!
+	}
+
+	type Service {
+		name: String!
+		version: String!
+		schema: String!
+	}`
+
+	schema := graphql.MustParseSchema(s, &gadgetServiceResolver{
+		serviceField: service{
+			Name:    "gadget-service",
+			Version: "v0.0.1",
+			Schema:  s,
+		},
+	}, graphql.UseFieldResolvers())
+
+	return httptest.NewServer(&relay.Handler{Schema: schema})
+}

--- a/testsrv/gizmo_test_server.go
+++ b/testsrv/gizmo_test_server.go
@@ -1,0 +1,107 @@
+package testsrv
+
+import (
+	"errors"
+	"net/http/httptest"
+
+	"github.com/graph-gophers/graphql-go"
+	"github.com/graph-gophers/graphql-go/relay"
+)
+
+type service struct {
+	Name    string
+	Version string
+	Schema  string
+}
+
+type gizmo struct {
+	IDField   string
+	NameField string
+}
+
+func (u gizmo) ID() graphql.ID {
+	return graphql.ID(u.IDField)
+}
+
+func (u gizmo) Name() string {
+	return u.NameField
+}
+
+var gizmos = []*gizmo{
+	{
+		IDField:   "GIZMO1",
+		NameField: "Gizmo #1",
+	},
+	{
+		IDField:   "GIZMO2",
+		NameField: "Gizmo #2",
+	},
+	{
+		IDField:   "GIZMO3",
+		NameField: "Gizmo #3",
+	},
+}
+
+var gizmosMap = make(map[string]*gizmo)
+
+func init() {
+	for _, gizmo := range gizmos {
+		gizmosMap[gizmo.IDField] = gizmo
+	}
+}
+
+type gizmoServiceResolver struct {
+	serviceField service
+}
+
+func (g *gizmoServiceResolver) Service() service {
+	return g.serviceField
+}
+
+func (g *gizmoServiceResolver) Gizmo(args struct{ ID string }) (*gizmo, error) {
+	gizmo, ok := gizmosMap[args.ID]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	return gizmo, nil
+}
+
+func (g *gizmoServiceResolver) BoundaryGizmo(args struct{ ID string }) (*gizmo, error) {
+	gizmo, ok := gizmosMap[args.ID]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	return gizmo, nil
+}
+
+func NewGizmoService() *httptest.Server {
+	s := `
+	directive @boundary on OBJECT | FIELD_DEFINITION
+
+	type Query {
+		service: Service!
+		gizmo(id: ID!): Gizmo!
+		boundaryGizmo(id: ID!): Gizmo @boundary
+	}
+
+	type Gizmo @boundary {
+		id: ID!
+		name: String!
+	}
+
+	type Service {
+		name: String!
+		version: String!
+		schema: String!
+	}`
+
+	schema := graphql.MustParseSchema(s, &gizmoServiceResolver{
+		serviceField: service{
+			Name:    "gizmo-service",
+			Version: "v0.0.1",
+			Schema:  s,
+		},
+	}, graphql.UseFieldResolvers())
+
+	return httptest.NewServer(&relay.Handler{Schema: schema})
+}


### PR DESCRIPTION
Following on from the work in #94. With that change in place there are certain aliases that are reserved for bramble's internal use, this changes the `__typename` alias to be `_bramble__typename`. 

**Rationale**

- create a pattern of reserved aliases starting with `_bramble`
- reduce the chance of someone wanting to genuinely use the `__typename` alias for different purposes being unable to do so
- because of the point above there should generally be no confusion about whether the client requested the `__typename` field or bramble injected it

As a side note, any bramble injected fields (that were also not explicitly requested) are automatically omitted from the final response. This is because the response formatting uses the client's selection set to decide what goes into the response. Also, in the future we could consider failing queries that include the reserved aliases entirely.

### New Test Suite

On top of the above changes there is a new minimal test suite, designed to test much more of bramble's internals in one go. The main difference between these tests and the tests in `execution_test.go` is the new suite will bring up and query real graphql servers. The tests are in `server_test.go` and the test server implementations in a package `testsrv`.

Given these servers are not mocked out there is a high overhead to new schemas and changes to what they now have. So the tests against them are minimal for now.

The biggest benefit of these tests is testing the plan against spec compliant graphql servers. The existing tests rely on manually crafted JSON to use as graphql responses and so don't test the plan itself but rather what the person writing the tests _thinks_ it should be. Manually writing JSON is also fairly error prone and can cause frustrating test failures.

They also give us a quick end to end test that makes sure bramble can fetch schemas of downstream services, merge these and then run queries on the merged schema.
