### PR TITLE
Refactor: interface selections have proper location

### DIFF
--- a/merge.go
+++ b/merge.go
@@ -59,7 +59,7 @@ func buildFieldURLMap(services ...*Service) FieldURLMap {
 	result := FieldURLMap{}
 	for _, rs := range services {
 		for _, t := range rs.Schema.Types {
-			if t.Kind != ast.Object || isGraphQLBuiltinName(t.Name) || t.Name == serviceObjectName {
+			if (t.Kind != ast.Object && t.Kind != ast.Interface) || isGraphQLBuiltinName(t.Name) || t.Name == serviceObjectName {
 				continue
 			}
 			for _, f := range mergeableFields(t) {

--- a/merge.go
+++ b/merge.go
@@ -59,7 +59,7 @@ func buildFieldURLMap(services ...*Service) FieldURLMap {
 	result := FieldURLMap{}
 	for _, rs := range services {
 		for _, t := range rs.Schema.Types {
-			if (t.Kind != ast.Object && t.Kind != ast.Interface) || isGraphQLBuiltinName(t.Name) || t.Name == serviceObjectName {
+			if !t.IsCompositeType() || isGraphQLBuiltinName(t.Name) || t.Name == serviceObjectName {
 				continue
 			}
 			for _, f := range mergeableFields(t) {

--- a/merge_test.go
+++ b/merge_test.go
@@ -448,6 +448,7 @@ func TestBuildFieldURLMapSingleSchema(t *testing.T) {
 		Location1: loc1,
 		Expected: FieldURLMap{
 			"Query.gizmo": loc1,
+			"Named.name":  loc1,
 			"Gizmo.id":    loc1,
 			"Gizmo.name":  loc1,
 		},
@@ -496,6 +497,8 @@ func TestBuildFieldURLMapTwoSchemasNoBoundaryType(t *testing.T) {
 			"Gizmo.name":    loc1,
 			"Gimmick.id":    loc2,
 			"Gimmick.size":  loc2,
+			"Named.name":    loc1,
+			"Sized.size":    loc2,
 		},
 	}
 	fixture.Check(t)
@@ -561,6 +564,9 @@ func TestBuildFieldURLMapTwoSchemasWithBoundaryType(t *testing.T) {
 			"Query.gizmo": loc1,
 			"Gizmo.name":  loc1,
 			"Gizmo.size":  loc2,
+			"Named.name":  loc1,
+			"Sized.size":  loc2,
+			"Node.id":     loc2,
 		},
 	}
 	fixture.Check(t)


### PR DESCRIPTION
As described in https://github.com/movio/bramble/issues/113, it's less than ideal that namespaces and interfaces are omitted from the `Locations` map, and therefore get [handled as error side-effects](https://github.com/movio/bramble/blob/main/plan.go#L140-L141):

```go
loc, err := ctx.Locations.URLFor(parentType, location, selection.Name)
// Errors are returned for unmapped namespace/interface locations
if err == nil && loc != location {
  // ...
}
```

These missing locations bank on a not-obvious rule that they're not allowed to transition services, so can alway use their parent object's location. Ideally these known resources would simply route to known locations, and missing location errors would be treated as _actual_ errors.

This adds interfaces to the `Locations` map so they become a properly routed resource.