### PR TITLE
Fix: broken namespace aliases and mutable selections

### DIFF
--- a/plan.go
+++ b/plan.go
@@ -138,18 +138,8 @@ func extractSelectionSet(ctx *PlanningContext, insertionPoint []string, parentTy
 				continue
 			}
 			loc, err := ctx.Locations.URLFor(parentType, location, selection.Name)
-			if err != nil {
-				// namespace
-				subSS, steps, err := extractSelectionSet(ctx, append(insertionPoint, selection.Name), selection.Definition.Type.Name(), selection.SelectionSet, location)
-				if err != nil {
-					return nil, nil, err
-				}
-				selection.SelectionSet = subSS
-				selectionSetResult = append(selectionSetResult, selection)
-				childrenStepsResult = append(childrenStepsResult, steps...)
-				continue
-			}
-			if loc != location {
+			// Errors are returned for unmapped namespace/interface locations (needs refactor)
+			if err == nil && loc != location {
 				// field transitions to another service location
 				remoteSelections = append(remoteSelections, selection)
 			} else if selection.SelectionSet == nil {
@@ -157,7 +147,6 @@ func extractSelectionSet(ctx *PlanningContext, insertionPoint []string, parentTy
 				selectionSetResult = append(selectionSetResult, selection)
 			} else {
 				// field is a composite type in the current service
-				newField := *selection
 				selectionSet, childrenSteps, err := extractSelectionSet(
 					ctx,
 					append(insertionPoint, selection.Alias),
@@ -168,6 +157,7 @@ func extractSelectionSet(ctx *PlanningContext, insertionPoint []string, parentTy
 				if err != nil {
 					return nil, nil, err
 				}
+				newField := *selection
 				newField.SelectionSet = selectionSet
 				selectionSetResult = append(selectionSetResult, &newField)
 				childrenStepsResult = append(childrenStepsResult, childrenSteps...)


### PR DESCRIPTION
Fixes some problems with namespace operations in the query planner, and simplifies the overall logic in the process.

## Problems + Fixes

```graphql
query {
  boo: myNamespace {
    product {
      name
    }
    manufacturer {
      name
    }
  }
}
```

* The namespace handler condition was demonstrably broken by field aliases: it [composed its insertion point](https://github.com/movio/bramble/pull/108/files#diff-11ffedf6a81044546aa19c8009998208f5a7afec3cdff04ca4281117b5ec0da7L143) using field `Name` rather than `Alias`. This issue is now fixed.

* The namespace condition could also corrupt the user's original selection because it modified fields directly rather than making copies. This was problematic because it modified the selection used to filter the final result, as described in https://github.com/movio/bramble/issues/106. This is also fixed.

* With the above adjustments made, the namespace condition ended up basically identical to the normal composite field handler. So, this simplifies the logic so that a failed location lookup now just flows into the normal field handlers; this new pattern has the added advantage of handing both leaf values and composite fields.

Resolves https://github.com/movio/bramble/issues/106 by happy accident.