### PR TITLE
Dynamic boundary argument

### DIFF
--- a/docs/sharing-types.md
+++ b/docs/sharing-types.md
@@ -73,24 +73,28 @@ extend Query {
 For Bramble to be able to request an arbitrary boundary object, every service
 defining boundary types must also implement a boundary query for each
 boundary object.
-This query takes an id and returns the associated object.
+This query takes exactly one id argument and returns the associated object.
 
-There are no restrictions on the name of a boundary query, only the return
-type is used to determine the matching boundary object.
+There are no restrictions on the name of a boundary query or its argument,
+only the return type is used to determine the matching boundary object.
 
 **Array syntax**
 
-Alternatively it is possible to define the boundary query with an array syntax:
+When possible, it's better to batch records by defining the boundary query as an array:
 
 ```graphql
 extend Query {
-    movies(ids: [ID!]): [Movie]! @boundary
+    movies(ids: [ID!]!): [Movie]! @boundary
 }
 ```
 
-In that case Bramble can query multiple IDs in the same query instead of
-doing multiple queries. This can make services more performant in some cases by
-reducing the need for dataloaders and the query complexity.
+With this syntax, Bramble will query multiple IDs as a set instead of requesting
+each record individually. This can make services more performant by
+reducing the need for dataloaders and lowering the overall query complexity.
+
+There are again no restrictions on the name of the boundary query or its argument.
+The resulting array expects to be a _mapped set_ matching the input length and order,
+with any missing records padded by null values.
 
 _Bramble query with regular boundary query_
 

--- a/execution_test.go
+++ b/execution_test.go
@@ -1498,7 +1498,7 @@ func TestBuildBoundaryQueryDocuments(t *testing.T) {
 		}
 	`
 	schema := gqlparser.MustLoadSchema(&ast.Source{Name: "fixture", Input: ddl})
-	boundaryField := BoundaryField{Field: "getOwners", Array: true}
+	boundaryField := BoundaryField{Field: "getOwners", Argument: "ids", Array: true}
 	ids := []string{"1", "2", "3"}
 	selectionSet := []ast.Selection{
 		&ast.Field{
@@ -1548,7 +1548,7 @@ func TestBuildNonArrayBoundaryQueryDocuments(t *testing.T) {
 		}
 	`
 	schema := gqlparser.MustLoadSchema(&ast.Source{Name: "fixture", Input: ddl})
-	boundaryField := BoundaryField{Field: "getOwner", Array: false}
+	boundaryField := BoundaryField{Field: "getOwner", Argument: "id", Array: false}
 	ids := []string{"1", "2", "3"}
 	selectionSet := []ast.Selection{
 		&ast.Field{
@@ -1598,7 +1598,7 @@ func TestBuildBatchedNonArrayBoundaryQueryDocuments(t *testing.T) {
 		}
 	`
 	schema := gqlparser.MustLoadSchema(&ast.Source{Name: "fixture", Input: ddl})
-	boundaryField := BoundaryField{Field: "getOwner", Array: false}
+	boundaryField := BoundaryField{Field: "getOwner", Argument: "id", Array: false}
 	ids := []string{"1", "2", "3"}
 	selectionSet := []ast.Selection{
 		&ast.Field{

--- a/merge.go
+++ b/merge.go
@@ -109,7 +109,7 @@ func buildBoundaryFieldsMap(services ...*Service) BoundaryFieldsMap {
 					array = true
 				}
 
-				result.RegisterField(rs.ServiceURL, typeName, f.Name, array)
+				result.RegisterField(rs.ServiceURL, typeName, f.Name, f.Arguments[0].Name, array)
 			}
 		}
 	}

--- a/plan.go
+++ b/plan.go
@@ -376,6 +376,8 @@ func (m FieldURLMap) keyFor(parent string, field string) string {
 // BoundaryField contains the name and format for a boundary query
 type BoundaryField struct {
 	Field string
+	// Name of the received id argument
+	Argument string
 	// Whether the query is in the array format
 	Array bool
 }
@@ -384,7 +386,7 @@ type BoundaryField struct {
 type BoundaryFieldsMap map[string]map[string]BoundaryField
 
 // RegisterField registers a boundary field
-func (m BoundaryFieldsMap) RegisterField(serviceURL, typeName, field string, array bool) {
+func (m BoundaryFieldsMap) RegisterField(serviceURL, typeName string, field string, argument string, array bool) {
 	if _, ok := m[serviceURL]; !ok {
 		m[serviceURL] = make(map[string]BoundaryField)
 	}
@@ -395,7 +397,7 @@ func (m BoundaryFieldsMap) RegisterField(serviceURL, typeName, field string, arr
 		return
 	}
 
-	m[serviceURL][typeName] = BoundaryField{Field: field, Array: array}
+	m[serviceURL][typeName] = BoundaryField{Field: field, Argument: argument, Array: array}
 }
 
 // Query returns the boundary field for the given service and type

--- a/plan_test.go
+++ b/plan_test.go
@@ -805,8 +805,8 @@ func TestQueryPlanWithNestedNamespaces(t *testing.T) {
 
 func TestPrefersArrayBasedBoundaryLookups(t *testing.T) {
 	boundaryFieldMap := make(BoundaryFieldsMap)
-	boundaryFieldMap.RegisterField("service-a", "movie", "_movie", true)
-	boundaryFieldMap.RegisterField("service-a", "movie", "_movies", false)
+	boundaryFieldMap.RegisterField("service-a", "movie", "_movie", "id", true)
+	boundaryFieldMap.RegisterField("service-a", "movie", "_movies", "ids", false)
 
 	boundaryField, err := boundaryFieldMap.Field("service-a", "movie")
 	require.NoError(t, err)

--- a/query_execution.go
+++ b/query_execution.go
@@ -427,7 +427,7 @@ func buildBoundaryQueryDocuments(ctx context.Context, schema *ast.Schema, step *
 			qids = append(qids, fmt.Sprintf("%q", id))
 		}
 		idsQL := fmt.Sprintf("[%s]", strings.Join(qids, ", "))
-		return []string{fmt.Sprintf(`{ _result: %s(ids: %s) %s }`, parentTypeBoundaryField.Field, idsQL, selectionSetQL)}, nil
+		return []string{fmt.Sprintf(`{ _result: %s(%s: %s) %s }`, parentTypeBoundaryField.Field, parentTypeBoundaryField.Argument, idsQL, selectionSetQL)}, nil
 	}
 
 	var (
@@ -437,7 +437,7 @@ func buildBoundaryQueryDocuments(ctx context.Context, schema *ast.Schema, step *
 	for _, batch := range batchBy(ids, batchSize) {
 		var selections []string
 		for _, id := range batch {
-			selection := fmt.Sprintf("%s: %s(id: %q) %s", fmt.Sprintf("_%d", selectionIndex), parentTypeBoundaryField.Field, id, selectionSetQL)
+			selection := fmt.Sprintf("%s: %s(%s: %q) %s", fmt.Sprintf("_%d", selectionIndex), parentTypeBoundaryField.Field, parentTypeBoundaryField.Argument, id, selectionSetQL)
 			selections = append(selections, selection)
 			selectionIndex++
 		}

--- a/validate.go
+++ b/validate.go
@@ -354,6 +354,10 @@ func validateBoundaryFields(schema *ast.Schema) error {
 				return fmt.Errorf("declared duplicate query for boundary type %q", f.Type.Name())
 			}
 
+			if len(f.Arguments) != 1 {
+				return fmt.Errorf("boundary field %q expects exactly one argument", f.Name)
+			}
+
 			boundaryTypes[f.Type.Name()] = true
 		}
 	}

--- a/validate_test.go
+++ b/validate_test.go
@@ -671,6 +671,34 @@ func TestSchemaValidateBoundaryFields(t *testing.T) {
 		}
 		`).assertInvalid(`declared duplicate query for boundary type "Foo"`, validateBoundaryFields)
 	})
+
+	t.Run("requires at least one arguments", func(t *testing.T) {
+		withSchema(t, `
+		directive @boundary on OBJECT | FIELD_DEFINITION
+
+		type Foo @boundary {
+			id: ID!
+		}
+
+		type Query {
+			foo: Foo @boundary
+		}
+		`).assertInvalid(`boundary field "foo" expects exactly one argument`, validateBoundaryFields)
+	})
+
+	t.Run("requires exactly one argument", func(t *testing.T) {
+		withSchema(t, `
+		directive @boundary on OBJECT | FIELD_DEFINITION
+
+		type Foo @boundary {
+			id: ID!
+		}
+
+		type Query {
+			foo(id: ID!, scope: String): Foo @boundary
+		}
+		`).assertInvalid(`boundary field "foo" expects exactly one argument`, validateBoundaryFields)
+	})
 }
 
 func TestSchemaValidateBoundaryObjectsFormat(t *testing.T) {


### PR DESCRIPTION
As discussed in https://github.com/movio/bramble/issues/97#issuecomment-968905753, this reads the name of each boundary query argument from the schema rather than hard-coding the argument names as `id` and `ids`. Now a boundary query naming is freeform so long as the field conforms to the basic signature of input and return:

```graphql
getMyThings(thingIds: [ID!]!): [Thing]! @boundary
```

This is an important first step in allowing the federation key to be customized for the graph, per https://github.com/movio/bramble/issues/109.