### PR TITLE
Improve Bramble timeout support

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -101,6 +101,26 @@ Set limits for response time and incoming requests size.
 }
 ```
 
+The limit for response time is applied to each sub-query. If a sub-query times out, it will return a null value with a corresponding error denoting the problematic selection set.
+
+e.g.
+
+```json
+{
+  "errors": {
+    "message": "error during request: Post \"http://localhost:8080/query\": context deadline exceeded",
+     "extensions": {
+        "selectionSet": "{ serviceB _bramble_id: id }"
+      },
+      ...
+  },
+  "data": {
+    "serviceA": "quick answer",
+    "serviceB": null
+  }
+}
+```
+
 ## Meta
 
 Adds meta-information to the graph.

--- a/execution_test.go
+++ b/execution_test.go
@@ -1036,7 +1036,7 @@ func TestQueryExecutionServiceTimeout(t *testing.T) {
 				}`,
 				handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 
-					time.Sleep(time.Second)
+					time.Sleep(time.Millisecond)
 
 					response := jsonToInterfaceMap(`{
 						"data": {
@@ -5704,6 +5704,9 @@ func (f *queryExecutionFixture) setup(t *testing.T) (*ExecutableSchema, func()) 
 	es.BoundaryQueries = buildBoundaryFieldsMap(services...)
 	es.Locations = buildFieldURLMap(services...)
 	es.IsBoundary = buildIsBoundaryMap(services...)
+	if t.Name() == "TestQueryExecutionServiceTimeout" {
+		es.GraphqlClient.HTTPClient.Timeout = time.Millisecond
+	}
 
 	return es, func() {
 		for _, close := range serverCloses {
@@ -5721,8 +5724,6 @@ func (f *queryExecutionFixture) run(t *testing.T) {
 		vars = map[string]interface{}{}
 	}
 	ctx := testContextWithVariables(vars, query.Operations[0])
-	ctx, cancel := context.WithTimeout(ctx, time.Second)
-	defer cancel()
 	if f.debug != nil {
 		ctx = context.WithValue(ctx, DebugKey, *f.debug)
 	}

--- a/execution_test.go
+++ b/execution_test.go
@@ -5721,6 +5721,8 @@ func (f *queryExecutionFixture) run(t *testing.T) {
 		vars = map[string]interface{}{}
 	}
 	ctx := testContextWithVariables(vars, query.Operations[0])
+	ctx, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
 	if f.debug != nil {
 		ctx = context.WithValue(ctx, DebugKey, *f.debug)
 	}

--- a/execution_test.go
+++ b/execution_test.go
@@ -1036,7 +1036,7 @@ func TestQueryExecutionServiceTimeout(t *testing.T) {
 				}`,
 				handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 
-					time.Sleep(time.Millisecond)
+					time.Sleep(300 * time.Millisecond)
 
 					response := jsonToInterfaceMap(`{
 						"data": {
@@ -5705,7 +5705,7 @@ func (f *queryExecutionFixture) setup(t *testing.T) (*ExecutableSchema, func()) 
 	es.Locations = buildFieldURLMap(services...)
 	es.IsBoundary = buildIsBoundaryMap(services...)
 	if t.Name() == "TestQueryExecutionServiceTimeout" {
-		es.GraphqlClient.HTTPClient.Timeout = time.Millisecond
+		es.GraphqlClient.HTTPClient.Timeout = 200 * time.Millisecond
 	}
 
 	return es, func() {

--- a/execution_test.go
+++ b/execution_test.go
@@ -9,8 +9,10 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/stretchr/testify/assert"
@@ -993,6 +995,96 @@ func TestQueryExecutionMultipleServices(t *testing.T) {
 	}
 
 	f.checkSuccess(t)
+}
+
+func TestQueryExecutionServiceTimeout(t *testing.T) {
+	f := &queryExecutionFixture{
+		services: []testService{
+			{
+				schema: `directive @boundary on OBJECT
+				type Movie @boundary {
+					id: ID!
+					title: String
+				}
+
+				type Query {
+					movie(id: ID!): Movie!
+				}`,
+				handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.Write([]byte(`{
+						"data": {
+							"movie": {
+								"_bramble_id": "1",
+								"id": "1",
+								"title": "Test title"
+							}
+						}
+					}
+					`))
+				}),
+			},
+			{
+				schema: `directive @boundary on OBJECT | FIELD_DEFINITION
+				type Movie @boundary {
+					id: ID!
+					release: Int
+					slowField: String
+				}
+
+				type Query {
+					movie(id: ID!): Movie! @boundary
+				}`,
+				handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+
+					time.Sleep(time.Second)
+
+					response := jsonToInterfaceMap(`{
+						"data": {
+							"_0": {
+								"_bramble_id": "1",
+								"id": "1",
+								"release": 2007,
+								"slowField": "very slow field"
+							}
+						}
+					}
+					`)
+					if err := json.NewEncoder(w).Encode(response); err != nil {
+						t.Errorf("Unexpected error %s", err)
+					}
+				}),
+			},
+		},
+		query: `{
+			movie(id: "1") {
+				id
+				title
+				slowField
+			}
+		}`,
+		expected: `{
+			"movie": {
+				"id": "1",
+				"title": "Test title",
+				"slowField": null
+			}
+		}`,
+		errors: gqlerror.List{
+			&gqlerror.Error{
+				Message: `error during request: Post \"http://127.0.0.1:\d{5}\": context deadline exceeded`,
+				Path:    ast.Path{ast.PathName("movie")},
+				Locations: []gqlerror.Location{
+					{Line: 5, Column: 5},
+				},
+				Extensions: map[string]interface{}{
+					"selectionSet": "{ slowField _bramble_id: id }",
+				},
+			},
+		},
+	}
+
+	f.run(t)
+	jsonEqWithOrder(t, f.expected, string(f.resp.Data))
 }
 
 func TestQueryExecutionNamespaceAndFragmentSpread(t *testing.T) {
@@ -5642,6 +5734,10 @@ func (f *queryExecutionFixture) run(t *testing.T) {
 		require.Equal(t, len(f.errors), len(f.resp.Errors))
 		for i := range f.errors {
 			delete(f.resp.Errors[i].Extensions, "serviceUrl")
+			// Allow regular expressions in expected error messages
+			if r, err := regexp.Compile(f.errors[i].Message); err == nil && r.Match([]byte(f.resp.Errors.Error())) {
+				f.errors[i].Message = f.resp.Errors[i].Message
+			}
 			require.Equal(t, *f.errors[i], *f.resp.Errors[i])
 		}
 	}

--- a/plugins/limits.go
+++ b/plugins/limits.go
@@ -63,5 +63,5 @@ func (p *LimitsPlugin) ApplyMiddlewarePublicMux(h http.Handler) http.Handler {
 		r.Body = http.MaxBytesReader(w, r.Body, p.config.MaxRequestBytes)
 		h.ServeHTTP(w, r)
 	})
-	return http.TimeoutHandler(handler, p.config.maxResponseDuration, "failed to serve query in time")
+	return handler
 }


### PR DESCRIPTION
## The Issue

Currently, if the limits plugin is used and a service times out, a generic 504 error is returned.


## Reproducing

For example, if you make a query that involves two services, where one is very slow.
```
query {
  serviceA {
    quickField
  }
  serviceB {
    slowField
  }
}
```
You will get  `HTTP/1.1 504 Gateway Timeout` or  `failed to serve query in time`

## The Fix

Instead of using `http.TimeoutHandler`, use the GraphQL client timeout that already exists and is set by the plugin.
This way the same query from above would return the results it has, fills the nullable fields in with nulls and bubble up the errors.

```
{
  "errors": {
    "message": "error during request: Post \"http://localhost:8092/query\": context deadline exceeded",
     ...
  }
  "data": {
    "serviceA": "quick answer",
    "serviceB": null
  }
}
```