### PR TITLE
Add custom http client option to GraphQLClient

### DIFF
--- a/client.go
+++ b/client.go
@@ -41,7 +41,7 @@ func NewClient(opts ...ClientOpt) *GraphQLClient {
 	return c
 }
 
-// WithHTTPClient set the http client used by the client.
+// WithHTTPClient sets a custom HTTP client to be used when making downstream queries.
 func WithHTTPClient(client *http.Client) ClientOpt {
 	return func(s *GraphQLClient) {
 		s.HTTPClient = client

--- a/client.go
+++ b/client.go
@@ -41,6 +41,13 @@ func NewClient(opts ...ClientOpt) *GraphQLClient {
 	return c
 }
 
+// WithHTTPClient set the http client used by the client.
+func WithHTTPClient(client *http.Client) ClientOpt {
+	return func(s *GraphQLClient) {
+		s.HTTPClient = client
+	}
+}
+
 // WithMaxResponseSize sets the max allowed response size. The client will only
 // read up to maxResponseSize and that size is exceeded an an error will be
 // returned.


### PR DESCRIPTION
Currently there is no way to customize the underlying HTTPClient used by the GraphQLClient.

There are many different usecases where HTTPClient needs to be customzied like introducing circuit breakers or custom roundtrippers.

I would like to introduce a new option to set custom HTTPClient.