### PR TITLE
Handle nullable destinations in results merge of query execution

### DIFF
--- a/query_execution.go
+++ b/query_execution.go
@@ -577,6 +577,9 @@ func mergeExecutionResultsRec(src interface{}, dst interface{}, insertionPoint [
 				return err
 			}
 		}
+	case nil:
+		// The destination is nil, so the src can not be merged
+		return nil
 	default:
 		return fmt.Errorf("mergeExecutionResultsRec: unxpected type '%T' for non top-level merge", ptr)
 	}


### PR DESCRIPTION
For fields that are nullable, it is possible that the merge algorithm will encounter some destinations that are `null`. It makes sense to skip those fields.

For example:

```graphql
# Service A
type Gizmo {
    id: ID!
    details: GizmoDetails
}

type GizmoDetails {
    creator: Person!
}

type Person @boundary {
    id: ID!
}

type Query {
    gizmos: [Gizmo!]!
}
````

```graphql
# Service B
type Person @boundary {
    id: ID!
    name: String!
}
type Query {
    person(id: ID!): Person @boundary
}
```

```graphql
query {
    gizmos {
        details {
            creator {
                name
            }
        }
    }
}
```

with results like:
```json
{
    "data": {
        "gizmos": [
            {
                "id": "GIZMO1",
                "details": {
                    "creator": {
                        "name": "Alice"
                    }
                }
            },
            {
                "id": "GIZMO2",
                "details": null
            }
        ]
    }
}
```

The merge algorithm would have expected to be able to walk down the `details`, `creator` path on `GIZMO2`.