### PR TITLE
Remove ModifyExtensions from plugin

### DIFF
--- a/execution.go
+++ b/execution.go
@@ -204,12 +204,6 @@ func (s *ExecutableSchema) ExecuteQuery(ctx context.Context) *graphql.Response {
 		}
 	}
 
-	for _, plugin := range s.plugins {
-		if err := plugin.ModifyExtensions(ctx, qe, extensions); err != nil {
-			AddField(ctx, fmt.Sprintf("%s-plugin-error", plugin.ID()), err.Error())
-		}
-	}
-
 	for _, result := range results {
 		errs = append(errs, result.Errors...)
 	}

--- a/plugin.go
+++ b/plugin.go
@@ -1,7 +1,6 @@
 package bramble
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 
@@ -25,7 +24,6 @@ type Plugin interface {
 	GraphqlQueryPath() (bool, string)
 	ApplyMiddlewarePublicMux(http.Handler) http.Handler
 	ApplyMiddlewarePrivateMux(http.Handler) http.Handler
-	ModifyExtensions(ctx context.Context, e *queryExecution, extensions map[string]interface{}) error
 }
 
 // BasePlugin is an empty plugin. It can be embedded by any plugin as a way to avoid
@@ -59,11 +57,6 @@ func (p *BasePlugin) ApplyMiddlewarePublicMux(h http.Handler) http.Handler {
 // ApplyMiddlewarePrivateMux ...
 func (p *BasePlugin) ApplyMiddlewarePrivateMux(h http.Handler) http.Handler {
 	return h
-}
-
-// ModifyExtensions ...
-func (p *BasePlugin) ModifyExtensions(ctx context.Context, e *queryExecution, extensions map[string]interface{}) error {
-	return nil
 }
 
 var registeredPlugins = map[string]Plugin{}


### PR DESCRIPTION
This PR aims to resolve the first point of issue #125. 
Removed `ModifyExtensions` as it doesn't seem to be used.