### PR TITLE
Improve "not currently supported" part of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,12 @@ It is also stateless and scales very easily.
 
 ## Future work/not currently supported
 
-There is currently no support for subscriptions.
+There is currently no support for:
+ 
+  - Subscriptions
+  - Shared unions, interfaces, and input objects across services
+
+Check FAQ for details: https://movio.github.io/bramble/#/federation?id=restriction-on-subscription
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ It is also stateless and scales very easily.
 There is currently no support for:
  
   - Subscriptions
-  - Shared unions, interfaces, and input objects across services
+  - Shared unions, interfaces, scalars, enums or inputs across services
 
 Check FAQ for details: https://movio.github.io/bramble/#/federation?id=restriction-on-subscription
 


### PR DESCRIPTION
Following Issue #136 , I just propose a quick README update to make it more explicit that unions can't be shared across services + a link to the FAQ to provide more details.