### PR TITLE
handle failed schema composition in merge test helper

### DIFF
--- a/merge_fixtures_test.go
+++ b/merge_fixtures_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/vektah/gqlparser/v2"
 	"github.com/vektah/gqlparser/v2/ast"
 )
@@ -89,7 +90,7 @@ func loadAndFormatSchema(input string) string {
 func mustMergeSchemas(t *testing.T, sources ...*ast.Schema) *ast.Schema {
 	t.Helper()
 	s, err := MergeSchemas(sources...)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	return s
 }
 


### PR DESCRIPTION
Schema composition can fail. If it does, it previously caused a panic through referencing a nil pointer.

In this case, it's better to return early.

I discovered this when experimenting with modifications to the schema composition logic, and instead of failing tests, I got the panic from the test helper.