### PR TITLE
Add nil pointer check for parent definition in extractSelectionSet

### DIFF
--- a/plan.go
+++ b/plan.go
@@ -228,6 +228,9 @@ func extractSelectionSet(ctx *PlanningContext, insertionPoint []string, parentTy
 	}
 
 	parentDef := ctx.Schema.Types[parentType]
+	if parentDef == nil {
+		return nil, nil, fmt.Errorf("definition is nil for parentType %v", parentType)
+	}
 	if parentDef.IsAbstractType() {
 		// For abstract types, add an id fragment for all possible boundary
 		// implementations. This assures that abstract boundaries always return

--- a/plan_test.go
+++ b/plan_test.go
@@ -836,3 +836,19 @@ func TestQueryPlanValidateReservedIdAlias(t *testing.T) {
 func TestQueryPlanValidateReservedTypenameAlias(t *testing.T) {
 	PlanTestFixture1.CheckError(t, "{ movies { _bramble__typename: title } }")
 }
+
+func TestExtractSelectionSetNilParentDefinition(t *testing.T) {
+	query := `
+	query {
+		animals {
+			... on Dog {
+				name
+				breed {
+					name
+					origin
+				}
+			}
+		}
+	}`
+	PlanTestFixture7.CheckNilPointer(t, query)
+}


### PR DESCRIPTION
`extractSelectionSet` seems to fail if a service is unreachable; which could be caused by missing schema information. 