### PR TITLE
Increase default polling period to 10 seconds.

### DIFF
--- a/config.go
+++ b/config.go
@@ -222,7 +222,7 @@ func GetConfig(configFiles []string) (*Config, error) {
 		PrivatePort:            8083,
 		MetricsPort:            9009,
 		LogLevel:               log.DebugLevel,
-		PollInterval:           "5s",
+		PollInterval:           "10s",
 		MaxRequestsPerQuery:    50,
 		MaxServiceResponseSize: 1024 * 1024,
 


### PR DESCRIPTION
This is to get around a race condition with nodejs based servers who
have a default HTTP Keep-Alive of 5 seconds.