### PR TITLE
Remove service polling client keep alive

### DIFF
--- a/client.go
+++ b/client.go
@@ -41,6 +41,24 @@ func NewClient(opts ...ClientOpt) *GraphQLClient {
 	return c
 }
 
+func NewClientWithoutKeepAlive(opts ...ClientOpt) *GraphQLClient {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.DisableKeepAlives = true
+	c := &GraphQLClient{
+		HTTPClient: &http.Client{
+			Timeout:   5 * time.Second,
+			Transport: transport,
+		},
+		MaxResponseSize: 1024 * 1024,
+	}
+
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	return c
+}
+
 // WithHTTPClient sets a custom HTTP client to be used when making downstream queries.
 func WithHTTPClient(client *http.Client) ClientOpt {
 	return func(s *GraphQLClient) {

--- a/client_test.go
+++ b/client_test.go
@@ -36,6 +36,23 @@ func TestGraphqlClient(t *testing.T) {
 		assert.Equal(t, "value", res.Root.Test)
 	})
 
+	t.Run("without keep-alive", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, "close", r.Header.Get("Connection"))
+			w.Write([]byte(`{
+				"data": {
+					"root": {
+						"test": "value"
+					}
+				}
+			}`))
+		}))
+
+		c := NewClientWithoutKeepAlive()
+		err := c.Request(context.Background(), srv.URL, &Request{}, nil)
+		assert.NoError(t, err)
+	})
+
 	t.Run("with http client", func(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			cookie, err := r.Cookie("test_cookie")

--- a/introspection.go
+++ b/introspection.go
@@ -24,7 +24,7 @@ type Service struct {
 func NewService(serviceURL string) *Service {
 	s := &Service{
 		ServiceURL: serviceURL,
-		client:     NewClient(WithUserAgent(GenerateUserAgent("update"))),
+		client:     NewClientWithoutKeepAlive(WithUserAgent(GenerateUserAgent("update"))),
 	}
 	return s
 }


### PR DESCRIPTION
## Problem

We've noticed errors like (`connection reset by peer` or `EOF`) when bramble polls certain services, most notably anything built on nodejs. After some investigation it turns out this is due to servers having a shorter `Keep-Alive` than bramble's http client, which can cause race conditions.

## Solution

Our first attempt was to introduce some randomness to the polling period with jitter. While this helped we still ran into the errors above.

It seems the most bullet proof way to not have race conditions is to have the client's `Keep-Alive` be shorter than the servers. Given service polling is not a high throughput task, we decided it's easier to just disable it entirely for this task. The http client bramble uses to run queries against downstream services is untouched.