### PR TITLE
Add operationName to bramble service poll

### DIFF
--- a/introspection.go
+++ b/introspection.go
@@ -31,7 +31,7 @@ func NewService(serviceURL string) *Service {
 
 // Update queries the service's schema, name and version and updates its status.
 func (s *Service) Update() (bool, error) {
-	req := NewRequest("{ service { name, version, schema} }")
+	req := NewRequest("query brambleServicePoll { service { name, version, schema} }")
 	response := struct {
 		Service struct {
 			Name    string `json:"name"`


### PR DESCRIPTION
Add an operationName to the service polling query. Can be used if any downstream services want to filter out these requests from logging etc.