### PR TITLE
Set operationName explicitly when polling

### DIFF
--- a/introspection.go
+++ b/introspection.go
@@ -32,6 +32,7 @@ func NewService(serviceURL string) *Service {
 // Update queries the service's schema, name and version and updates its status.
 func (s *Service) Update() (bool, error) {
 	req := NewRequest("query brambleServicePoll { service { name, version, schema} }")
+	req.OperationName = "brambleServicePoll"
 	response := struct {
 		Service struct {
 			Name    string `json:"name"`


### PR DESCRIPTION
Some downstream servers do not infer the operationName from the selection set and some do. Make the name explicit to make sure it's compatible with all downstream servers.