### PR TITLE
Fix fragment spread elimination during result merge + format

### DIFF
--- a/execution.go
+++ b/execution.go
@@ -690,7 +690,7 @@ func (s *ExecutableSchema) evaluateSkipAndIncludeRec(vars map[string]interface{}
 					Name:             selection.Name,
 					Directives:       removeSkipAndInclude(selection.Directives),
 					Position:         selection.Position,
-					ObjectDefinition: selection.Definition.Definition,
+					ObjectDefinition: selection.ObjectDefinition,
 					Definition: &ast.FragmentDefinition{
 						Name:               selection.Definition.Name,
 						VariableDefinition: selection.Definition.VariableDefinition,

--- a/execution_test.go
+++ b/execution_test.go
@@ -984,6 +984,59 @@ func TestFederatedQueryFragmentSpreads(t *testing.T) {
 		f.checkSuccess(t)
 	})
 
+	t.Run("with multiple top level fragment spreads (gadget implementation)", func(t *testing.T) {
+		f := &queryExecutionFixture{
+			services: []testService{serviceA, serviceB},
+			query: `
+			query Foo {
+				snapshot(id: "GADGET1") {
+					id
+					name
+					... GadgetFragment
+					... GizmoFragment
+				}
+			}
+
+			fragment GadgetFragment on GadgetImplementation {
+				gadgets {
+					id
+					name
+					agents {
+						name
+						... on Agent {
+							country
+						}
+					}
+				}
+			}
+
+			fragment GizmoFragment on GizmoImplementation {
+				gizmos {
+					id
+					name
+				}
+			}`,
+			expected: `
+			{
+				"snapshot": {
+					"id": "100",
+					"name": "foo",
+					"gadgets": [
+						{
+							"id": "GADGET1",
+							"name": "Gadget #1",
+							"agents": [
+								{"name": "James Bond", "country": "UK"}
+							]
+						}
+					]
+				}
+			}`,
+		}
+
+		f.checkSuccess(t)
+	})
+
 }
 
 func TestQueryExecutionMultipleServices(t *testing.T) {


### PR DESCRIPTION
FIxes: #151 

There was an issue multiple top level named fragment spreads under an interface type were not being correctly eliminated during the merge and format stages of query execution.

The behaviour should be that for both inline and named fragment spreads, only the spread that matches the concrete type in the response is kept. This was working for inline spreads but not named spreads.

The problem was made a little harder to fix due to an existing problem with `evaluateSkipAndInclude` that would overwrite the `ObjectDefinition` for a `FragmentSpread` with the wrong value.

This PR fixes both issues.