### PR TITLE
Ensure the destination map for merging is never nil

### DIFF
--- a/execution.go
+++ b/execution.go
@@ -490,6 +490,15 @@ func mergeExecutionResults(results []executionResult) (map[string]interface{}, e
 	}
 
 	data := results[0].Data
+	switch ptr := data.(type) {
+	case nil:
+		data = make(map[string]interface{})
+	case map[string]interface{}:
+		if ptr == nil {
+			data = make(map[string]interface{})
+		}
+	}
+
 	for _, result := range results[1:] {
 		if err := mergeExecutionResultsRec(result.Data, data, result.InsertionPoint); err != nil {
 			return nil, err

--- a/execution_test.go
+++ b/execution_test.go
@@ -5794,6 +5794,27 @@ func TestQueryWithArrayBoundaryFields(t *testing.T) {
 	f.checkSuccess(t)
 }
 
+func TestMergeWithNull(t *testing.T) {
+	nullMap := make(map[string]interface{})
+	dataMap := map[string]interface{}{
+		"data": "foo",
+	}
+
+	require.NoError(t, json.Unmarshal([]byte(`null`), &nullMap))
+
+	merged, err := mergeExecutionResults([]executionResult{
+		{
+			Data: nullMap,
+		},
+		{
+			Data: dataMap,
+		},
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, dataMap, merged)
+}
+
 func TestSchemaUpdate_serviceError(t *testing.T) {
 	schemaA := `directive @boundary on OBJECT
 				type Service {


### PR DESCRIPTION
Bramble currently panic when the data in the first entry of `executionResults` was marshalled from a json null. This is due to us ending up with a typed nil as our destination map that wasn't being caught. 

The PR ensures that the first destination map passed into the merge is never nil.