### PR TITLE
Use the default cloudflare recommended timeouts

### DIFF
--- a/main.go
+++ b/main.go
@@ -64,8 +64,11 @@ func Main() {
 
 func runHandler(ctx context.Context, wg *sync.WaitGroup, name, addr string, handler http.Handler) {
 	srv := &http.Server{
-		Addr:    addr,
-		Handler: handler,
+		Addr:         addr,
+		Handler:      handler,
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 10 * time.Second,
+		IdleTimeout:  120 * time.Second,
 	}
 
 	go func() {


### PR DESCRIPTION
Use the [cloudflare recommended default timeouts](https://blog.cloudflare.com/exposing-go-on-the-internet/#timeouts) for `http.Server` as recommended by @aerfio in #161

This might be worth being configurable, especially if used in combination with the `max-response-time` of the limits plugin.