### PR TITLE
Populate PossibleTypes with merged type

### DIFF
--- a/merge.go
+++ b/merge.go
@@ -242,7 +242,7 @@ func mergePossibleTypes(sources []*ast.Schema, mergedTypes map[string]*ast.Defin
 				for _, possibleType := range possibleTypes {
 					if possibleType.Name != nodeInterfaceName {
 						if ast.DefinitionList(result[typeName]).ForName(possibleType.Name) == nil {
-							result[typeName] = append(result[typeName], possibleType)
+							result[typeName] = append(result[typeName], mergedTypes[possibleType.Name])
 						}
 					}
 				}

--- a/merge.go
+++ b/merge.go
@@ -234,15 +234,15 @@ func mergeDirectives(sources []*ast.Schema) map[string]*ast.DirectiveDefinition 
 func mergePossibleTypes(sources []*ast.Schema, mergedTypes map[string]*ast.Definition) map[string][]*ast.Definition {
 	result := map[string][]*ast.Definition{}
 	for _, schema := range sources {
-		for typeName, interfaces := range schema.PossibleTypes {
+		for typeName, possibleTypes := range schema.PossibleTypes {
 			if typeName != serviceObjectName && typeName != nodeInterfaceName {
 				if _, ok := mergedTypes[typeName]; !ok {
 					continue
 				}
-				for _, i := range interfaces {
-					if i.Name != nodeInterfaceName {
-						if ast.DefinitionList(result[typeName]).ForName(i.Name) == nil {
-							result[typeName] = append(result[typeName], i)
+				for _, possibleType := range possibleTypes {
+					if possibleType.Name != nodeInterfaceName {
+						if ast.DefinitionList(result[typeName]).ForName(possibleType.Name) == nil {
+							result[typeName] = append(result[typeName], possibleType)
 						}
 					}
 				}

--- a/merge_fixtures_test.go
+++ b/merge_fixtures_test.go
@@ -113,7 +113,17 @@ func assertSchemaPossibleTypesConsistency(t *testing.T, schema *ast.Schema) {
 	t.Helper()
 	actual := getPossibleTypes(schema)
 	expected := getPossibleTypes(loadSchema(formatSchema(schema)))
-	assert.Equal(t, expected, actual, "schema.PossibleTypes is not consistent")
+	actualKeys, expectedKeys := []string{}, []string{}
+	for key := range actual {
+		actualKeys = append(actualKeys, key)
+	}
+	for key := range expected {
+		expectedKeys = append(expectedKeys, key)
+	}
+	assert.ElementsMatch(t, expectedKeys, actualKeys, "schema.PossibleTypes is not consistent")
+	for typeName := range actual {
+		assert.ElementsMatchf(t, actual[typeName], expected[typeName], "schema.PossibleTypes[%s] is not consistent", typeName)
+	}
 }
 
 func assertSchemaIntrospectionTypes(t *testing.T, schema *ast.Schema) {

--- a/merge_test.go
+++ b/merge_test.go
@@ -923,3 +923,79 @@ func TestMergeWithAlternateId(t *testing.T) {
 	fixture.CheckSuccess(t)
 	IdFieldName = "id" // reset!
 }
+
+func TestMergePossibleTypes(t *testing.T) {
+	fixture := MergeTestFixture{
+		Input1: `
+			directive @boundary on OBJECT | FIELD_DEFINITION
+
+			interface Face {
+				id: ID!
+			}
+
+			type Foo implements Face @boundary {
+				id: ID!
+				foo: Boolean!
+			}
+
+			type Bar implements Face {
+				id: ID!
+				bar: Boolean!
+			}
+
+			type Query  {
+				faces: [Face!]!
+				face(id: ID!): Face @boundary
+				service: Service!
+			}
+
+			type Service {
+				name: String!
+				version: String!
+				schema: String!
+			}
+		`,
+		Input2: `
+			directive @boundary on OBJECT | FIELD_DEFINITION
+
+			type Foo @boundary {
+				id: ID!
+				superfoo: Boolean!
+			}
+
+			type Query  {
+				face(id: ID!): Foo @boundary
+				service: Service!
+			}
+
+			type Service {
+				name: String!
+				version: String!
+				schema: String!
+			}
+	`,
+		Expected: `
+			directive @boundary on OBJECT | FIELD_DEFINITION
+
+			interface Face {
+				id: ID!
+			}
+
+			type Foo implements Face @boundary {
+				id: ID!
+				superfoo: Boolean!
+				foo: Boolean!
+			}
+
+			type Bar implements Face {
+				id: ID!
+				bar: Boolean!
+			}
+
+			type Query  {
+				faces: [Face!]!
+			}
+		`,
+	}
+	fixture.CheckSuccess(t)
+}


### PR DESCRIPTION
The `mergePossibleTypes` function when populating the types just used the value from one of the source trees instead of the merged type.

This would only be apparent once one type of an `interface` was a `@boundary` type, depending on the order the services were merged in the final merged schema could be missing fields from other services.