### PR TITLE
Abstract type boundary federation

### DIFF
--- a/execution.go
+++ b/execution.go
@@ -387,9 +387,6 @@ func extractBoundaryIDs(data interface{}, insertionPoint []string) ([]string, er
 		switch ptr := ptr.(type) {
 		case map[string]interface{}:
 			id, err := boundaryIDFromMap(ptr)
-			if err != nil {
-				return []string{}, nil
-			}
 			return []string{id}, err
 		case []interface{}:
 			result := []string{}

--- a/execution.go
+++ b/execution.go
@@ -387,6 +387,9 @@ func extractBoundaryIDs(data interface{}, insertionPoint []string) ([]string, er
 		switch ptr := ptr.(type) {
 		case map[string]interface{}:
 			id, err := boundaryIDFromMap(ptr)
+			if err != nil {
+				return []string{}, nil
+			}
 			return []string{id}, err
 		case []interface{}:
 			result := []string{}

--- a/execution.go
+++ b/execution.go
@@ -108,7 +108,7 @@ func (q *queryExecution) executeRootStep(step *QueryPlanStep) error {
 	q.writeExecutionResult(step, data, nil)
 
 	for _, childStep := range step.Then {
-		boundaryIDs, err := extractAndDedupeBoundaryIDs(data, childStep.InsertionPoint)
+		boundaryIDs, err := extractAndDedupeBoundaryIDs(data, childStep.InsertionPoint, childStep.ParentType)
 		if err != nil {
 			return err
 		}
@@ -175,7 +175,7 @@ func (q *queryExecution) executeChildStep(step *QueryPlanStep, boundaryIDs []str
 			if err != nil {
 				return err
 			}
-			boundaryIDs, err := extractAndDedupeBoundaryIDs(nonNilBoundaryResults, boundaryResultInsertionPoint)
+			boundaryIDs, err := extractAndDedupeBoundaryIDs(nonNilBoundaryResults, boundaryResultInsertionPoint, childStep.ParentType)
 			if err != nil {
 				return err
 			}
@@ -359,8 +359,8 @@ func buildTypenameResponseMap(selectionSet ast.SelectionSet, parentTypeName stri
 	return result, nil
 }
 
-func extractAndDedupeBoundaryIDs(data interface{}, insertionPoint []string) ([]string, error) {
-	boundaryIDs, err := extractBoundaryIDs(data, insertionPoint)
+func extractAndDedupeBoundaryIDs(data interface{}, insertionPoint []string, parentType string) ([]string, error) {
+	boundaryIDs, err := extractBoundaryIDs(data, insertionPoint, parentType)
 	if err != nil {
 		return nil, err
 	}
@@ -377,7 +377,7 @@ func extractAndDedupeBoundaryIDs(data interface{}, insertionPoint []string) ([]s
 	return deduped, nil
 }
 
-func extractBoundaryIDs(data interface{}, insertionPoint []string) ([]string, error) {
+func extractBoundaryIDs(data interface{}, insertionPoint []string, parentType string) ([]string, error) {
 	ptr := data
 	if ptr == nil {
 		return nil, nil
@@ -385,15 +385,21 @@ func extractBoundaryIDs(data interface{}, insertionPoint []string) ([]string, er
 	if len(insertionPoint) == 0 {
 		switch ptr := ptr.(type) {
 		case map[string]interface{}:
-			id := boundaryIDFromMap(ptr)
-			if id == "" {
+			tpe, err := boundaryTypeFromMap(ptr)
+			if err != nil {
+				return nil, err
+			}
+
+			if tpe != parentType {
 				return []string{}, nil
 			}
-			return []string{id}, nil
+
+			id, err := boundaryIDFromMap(ptr)
+			return []string{id}, err
 		case []interface{}:
 			var result []string
 			for _, innerPtr := range ptr {
-				ids, err := extractBoundaryIDs(innerPtr, insertionPoint)
+				ids, err := extractBoundaryIDs(innerPtr, insertionPoint, parentType)
 				if err != nil {
 					return nil, err
 				}
@@ -406,11 +412,11 @@ func extractBoundaryIDs(data interface{}, insertionPoint []string) ([]string, er
 	}
 	switch ptr := ptr.(type) {
 	case map[string]interface{}:
-		return extractBoundaryIDs(ptr[insertionPoint[0]], insertionPoint[1:])
+		return extractBoundaryIDs(ptr[insertionPoint[0]], insertionPoint[1:], parentType)
 	case []interface{}:
 		var result []string
 		for _, innerPtr := range ptr {
-			ids, err := extractBoundaryIDs(innerPtr, insertionPoint)
+			ids, err := extractBoundaryIDs(innerPtr, insertionPoint, parentType)
 			if err != nil {
 				return nil, err
 			}

--- a/execution_helpers_test.go
+++ b/execution_helpers_test.go
@@ -553,30 +553,38 @@ func TestExtractBoundaryIDs(t *testing.T) {
 		"gizmos": [
 			{
 				"_bramble_id": "1",
+				"_bramble__typename": "Gizmo",
 				"name": "Gizmo 1",
 				"owner": {
-					"_bramble_id": "1"
+					"_bramble_id": "1",
+					"_bramble__typename": "Owner"
 				}
 			},
 			{
 				"_bramble_id": "2",
+				"_bramble__typename": "Gizmo",
 				"name": "Gizmo 2",
 				"owner": {
-					"_bramble_id": "1"
+					"_bramble_id": "1",
+					"_bramble__typename": "Owner"
 				}
 			},
 			{
 				"_bramble_id": "3",
+				"_bramble__typename": "Gizmo",
 				"name": "Gizmo 3",
 				"owner": {
-					"_bramble_id": "2"
+					"_bramble_id": "2",
+					"_bramble__typename": "Owner"
 				}
 			},
 			{
 				"_bramble_id": "4",
+				"_bramble__typename": "Gizmo",
 				"name": "Gizmo 4",
 				"owner": {
-					"_bramble_id": "5"
+					"_bramble_id": "5",
+					"_bramble__typename": "Owner"
 				}
 			}
 		]
@@ -585,7 +593,7 @@ func TestExtractBoundaryIDs(t *testing.T) {
 	expected := []string{"1", "1", "2", "5"}
 	insertionPoint := []string{"gizmos", "owner"}
 	require.NoError(t, json.Unmarshal([]byte(dataJSON), &data))
-	result, err := extractBoundaryIDs(data, insertionPoint)
+	result, err := extractBoundaryIDs(data, insertionPoint, "Owner")
 	require.NoError(t, err)
 	require.Equal(t, expected, result)
 }

--- a/execution_result.go
+++ b/execution_result.go
@@ -73,15 +73,11 @@ func mergeExecutionResultsRec(src interface{}, dst interface{}, insertionPoint [
 					return err
 				}
 
-				dstID, err := boundaryIDFromMap(ptr)
-				if err != nil {
-					return err
-				}
-
+				dstID := boundaryIDFromMap(ptr)
 				for _, result := range boundaryResults {
-					srcID, err := boundaryIDFromMap(result)
-					if err != nil {
-						return err
+					srcID := boundaryIDFromMap(result)
+					if dstID == "" || srcID == "" {
+						continue
 					}
 					if srcID == dstID {
 						for k, v := range result {
@@ -137,12 +133,12 @@ func mergeExecutionResultsRec(src interface{}, dst interface{}, insertionPoint [
 	return nil
 }
 
-func boundaryIDFromMap(boundaryMap map[string]interface{}) (string, error) {
+func boundaryIDFromMap(boundaryMap map[string]interface{}) string {
 	id, ok := boundaryMap["_bramble_id"].(string)
 	if ok {
-		return id, nil
+		return id
 	}
-	return "", fmt.Errorf(`boundaryIDFromMap: "_bramble_id" not found`)
+	return ""
 }
 
 func getBoundaryFieldResults(src []interface{}) ([]map[string]interface{}, error) {

--- a/execution_result.go
+++ b/execution_result.go
@@ -142,7 +142,7 @@ func boundaryIDFromMap(boundaryMap map[string]interface{}) (string, error) {
 	if ok {
 		return id, nil
 	}
-	return "", errors.New("boundaryIDFromMap: \"_bramble_id\" not found")
+	return "", fmt.Errorf(`boundaryIDFromMap: "_bramble_id" not found`)
 }
 
 func getBoundaryFieldResults(src []interface{}) ([]map[string]interface{}, error) {

--- a/execution_result.go
+++ b/execution_result.go
@@ -75,13 +75,13 @@ func mergeExecutionResultsRec(src interface{}, dst interface{}, insertionPoint [
 
 				dstID, err := boundaryIDFromMap(ptr)
 				if err != nil {
-					return err
+					return nil
 				}
 
 				for _, result := range boundaryResults {
 					srcID, err := boundaryIDFromMap(result)
 					if err != nil {
-						return err
+						return nil
 					}
 					if srcID == dstID {
 						for k, v := range result {

--- a/execution_result.go
+++ b/execution_result.go
@@ -75,13 +75,13 @@ func mergeExecutionResultsRec(src interface{}, dst interface{}, insertionPoint [
 
 				dstID, err := boundaryIDFromMap(ptr)
 				if err != nil {
-					return nil
+					return err
 				}
 
 				for _, result := range boundaryResults {
 					srcID, err := boundaryIDFromMap(result)
 					if err != nil {
-						return nil
+						return err
 					}
 					if srcID == dstID {
 						for k, v := range result {

--- a/execution_result_test.go
+++ b/execution_result_test.go
@@ -79,10 +79,11 @@ func TestMergeExecutionResults(t *testing.T) {
 		inputMapA := jsonToInterfaceMap(`{
 			"gizmo": {
 				"_bramble_id": "1",
+				"_bramble__typename": "Gizmo",
 				"gadgets": [
-					{"_bramble_id": "GADGET1", "owner": { "_bramble_id": "OWNER1" }},
-					{"_bramble_id": "GADGET3", "owner": { "_bramble_id": "OWNER3" }},
-					{"_bramble_id": "GADGET2", "owner": null}
+					{"_bramble_id": "GADGET1", "_bramble__typename": "Gadget", "owner": { "_bramble_id": "OWNER1", "_bramble__typename": "Owner" }},
+					{"_bramble_id": "GADGET3", "_bramble__typename": "Gadget", "owner": { "_bramble_id": "OWNER3", "_bramble__typename": "Owner" }},
+					{"_bramble_id": "GADGET2", "_bramble__typename": "Gadget", "owner": null}
 				]
 			}
 		}`)
@@ -96,6 +97,7 @@ func TestMergeExecutionResults(t *testing.T) {
 		inputMapB := jsonToInterfaceSlice(`[
 			{
 				"_bramble_id": "OWNER1",
+				"_bramble__typename": "Owner",
 				"name": "008"
 			}
 		]`)
@@ -114,23 +116,29 @@ func TestMergeExecutionResults(t *testing.T) {
 				"gadgets": [
 					{
 						"_bramble_id": "GADGET1",
+						"_bramble__typename": "Gadget",
 						"owner": {
 							"_bramble_id": "OWNER1",
+							"_bramble__typename": "Owner",
 							"name": "008"
 						}
 					},
 					{
 						"_bramble_id": "GADGET3",
+						"_bramble__typename": "Gadget",
 						"owner": {
-							"_bramble_id": "OWNER3"
+							"_bramble_id": "OWNER3",
+							"_bramble__typename": "Owner"
 						}
 					},
 					{
 						"_bramble_id": "GADGET2",
+						"_bramble__typename": "Gadget",
 						"owner": null
 					}
 				],
-				"_bramble_id": "1"
+				"_bramble_id": "1",
+				"_bramble__typename": "Gizmo"
 			}
 		}`)
 
@@ -142,13 +150,14 @@ func TestMergeExecutionResults(t *testing.T) {
 		inputMapA := jsonToInterfaceMap(`{
 			"gizmo": {
 				"_bramble_id": "1",
+				"_bramble__typename": "Gizmo",
 				"gadgets": [
 					[
-						{"_bramble_id": "GADGET1", "owner": { "_bramble_id": "OWNER1" }},
-						{"_bramble_id": "GADGET3", "owner": { "_bramble_id": "OWNER3" }}
+						{"_bramble_id": "GADGET1", "_bramble__typename": "Gadget", "owner": { "_bramble_id": "OWNER1", "_bramble__typename": "Owner" }},
+						{"_bramble_id": "GADGET3", "_bramble__typename": "Gadget", "owner": { "_bramble_id": "OWNER3", "_bramble__typename": "Owner" }}
 					],
 					[
-						{"_bramble_id": "GADGET2", "owner": null}
+						{"_bramble_id": "GADGET2", "_bramble__typename": "Gadget", "owner": null}
 					]
 				]
 			}
@@ -163,6 +172,7 @@ func TestMergeExecutionResults(t *testing.T) {
 		inputMapB := jsonToInterfaceSlice(`[
 			{
 				"_bramble_id": "OWNER1",
+				"_bramble__typename": "Owner",
 				"name": "008"
 			}
 		]`)
@@ -182,26 +192,32 @@ func TestMergeExecutionResults(t *testing.T) {
 					[
 						{
 							"_bramble_id": "GADGET1",
+							"_bramble__typename": "Gadget",
 							"owner": {
 								"_bramble_id": "OWNER1",
+								"_bramble__typename": "Owner",
 								"name": "008"
 							}
 						},
 						{
 							"_bramble_id": "GADGET3",
+							"_bramble__typename": "Gadget",
 							"owner": {
-								"_bramble_id": "OWNER3"
+								"_bramble_id": "OWNER3",
+								"_bramble__typename": "Owner"
 							}
 						}
 					],
 					[
 						{
 							"_bramble_id": "GADGET2",
+							"_bramble__typename": "Gadget",
 							"owner": null
 						}
 					]
 				],
-				"_bramble_id": "1"
+				"_bramble_id": "1",
+				"_bramble__typename": "Gizmo"
 			}
 		}`)
 
@@ -215,7 +231,8 @@ func TestMergeExecutionResults(t *testing.T) {
 				"id": "1",
 				"color": "Gizmo A",
 				"owner": {
-					"_bramble_id": "1"
+					"_bramble_id": "1",
+					"_bramble__typename": "Owner"
 				}
 			}
 		}`)
@@ -229,6 +246,7 @@ func TestMergeExecutionResults(t *testing.T) {
 		inputSliceB := jsonToInterfaceSlice(`[
 			{
 				"_bramble_id": "1",
+				"_bramble__typename": "Owner",
 				"name": "Owner A"
 			}
 		]`)
@@ -247,6 +265,7 @@ func TestMergeExecutionResults(t *testing.T) {
 				"color": "Gizmo A",
 				"owner": {
 					"_bramble_id": "1",
+					"_bramble__typename": "Owner",
 					"name": "Owner A"
 				}
 			}
@@ -263,21 +282,24 @@ func TestMergeExecutionResults(t *testing.T) {
 					"id": "1",
 					"color": "RED",
 					"owner": {
-						"_bramble_id": "4"
+						"_bramble_id": "4",
+						"_bramble__typename": "Owner"
 					}
 				},
 				{
 					"id": "2",
 					"color": "GREEN",
 					"owner": {
-						"_bramble_id": "5"
+						"_bramble_id": "5",
+						"_bramble__typename": "Owner"
 					}
 				},
 				{
 					"id": "3",
 					"color": "BLUE",
 					"owner": {
-						"_bramble_id": "6"
+						"_bramble_id": "6",
+						"_bramble__typename": "Owner"
 					}
 				}
 			]
@@ -292,14 +314,17 @@ func TestMergeExecutionResults(t *testing.T) {
 		inputSliceB := jsonToInterfaceSlice(`[
 			{
 				"_bramble_id": "4",
+				"_bramble__typename": "Owner",
 				"name": "Owner A"
 			},
 			{
 				"_bramble_id": "5",
+				"_bramble__typename": "Owner",
 				"name": "Owner B"
 			},
 			{
 				"_bramble_id": "6",
+				"_bramble__typename": "Owner",
 				"name": "Owner C"
 			}
 		]`)
@@ -319,6 +344,7 @@ func TestMergeExecutionResults(t *testing.T) {
 					"color": "RED",
 					"owner": {
 						"_bramble_id": "4",
+						"_bramble__typename": "Owner",
 						"name": "Owner A"
 					}
 				},
@@ -327,6 +353,7 @@ func TestMergeExecutionResults(t *testing.T) {
 					"color": "GREEN",
 					"owner": {
 						"_bramble_id": "5",
+						"_bramble__typename": "Owner",
 						"name": "Owner B"
 					}
 				},
@@ -335,6 +362,7 @@ func TestMergeExecutionResults(t *testing.T) {
 					"color": "BLUE",
 					"owner": {
 						"_bramble_id": "6",
+						"_bramble__typename": "Owner",
 						"name": "Owner C"
 					}
 				}
@@ -352,21 +380,24 @@ func TestMergeExecutionResults(t *testing.T) {
 					"id": "1",
 					"color": "RED",
 					"owner": {
-						"_bramble_id": "4"
+						"_bramble_id": "4",
+						"_bramble__typename": "Owner"
 					}
 				},
 				{
 					"id": "2",
 					"color": "GREEN",
 					"owner": {
-						"_bramble_id": "5"
+						"_bramble_id": "5",
+						"_bramble__typename": "Owner"
 					}
 				},
 				{
 					"id": "3",
 					"color": "BLUE",
 					"owner": {
-						"_bramble_id": "6"
+						"_bramble_id": "6",
+						"_bramble__typename": "Owner"
 					}
 				}
 			]
@@ -381,14 +412,17 @@ func TestMergeExecutionResults(t *testing.T) {
 		inputSliceB := jsonToInterfaceSlice(`[
 			{
 				"_bramble_id": "4",
+				"_bramble__typename": "Owner",
 				"name": "Owner A"
 			},
 			{
 				"_bramble_id": "5",
+				"_bramble__typename": "Owner",
 				"name": "Owner B"
 			},
 			{
 				"_bramble_id": "6",
+				"_bramble__typename": "Owner",
 				"name": "Owner C"
 			}
 		]`)
@@ -408,6 +442,7 @@ func TestMergeExecutionResults(t *testing.T) {
 					"color": "RED",
 					"owner": {
 						"_bramble_id": "4",
+						"_bramble__typename": "Owner",
 						"name": "Owner A"
 					}
 				},
@@ -416,6 +451,7 @@ func TestMergeExecutionResults(t *testing.T) {
 					"color": "GREEN",
 					"owner": {
 						"_bramble_id": "5",
+						"_bramble__typename": "Owner",
 						"name": "Owner B"
 					}
 				},
@@ -424,6 +460,7 @@ func TestMergeExecutionResults(t *testing.T) {
 					"color": "BLUE",
 					"owner": {
 						"_bramble_id": "6",
+						"_bramble__typename": "Owner",
 						"name": "Owner C"
 					}
 				}
@@ -439,23 +476,29 @@ func TestMergeExecutionResults(t *testing.T) {
 			"gizmos": [
 				{
 					"_bramble_id": "1",
+					"_bramble__typename": "Gizmo",
 					"color": "RED",
 					"owner": {
-						"_bramble_id": "4"
+						"_bramble_id": "4",
+						"_bramble__typename": "Owner"
 					}
 				},
 				{
 					"_bramble_id": "2",
+					"_bramble__typename": "Gizmo",
 					"color": "GREEN",
 					"owner": {
-						"_bramble_id": "5"
+						"_bramble_id": "5",
+						"_bramble__typename": "Owner"
 					}
 				},
 				{
 					"_bramble_id": "3",
+					"_bramble__typename": "Gizmo",
 					"color": "BLUE",
 					"owner": {
-						"_bramble_id": "6"
+						"_bramble_id": "6",
+						"_bramble__typename": "Owner"
 					}
 				}
 			]
@@ -470,14 +513,17 @@ func TestMergeExecutionResults(t *testing.T) {
 		inputSliceB := jsonToInterfaceSlice(`[
 			{
 				"_bramble_id": "4",
+				"_bramble__typename": "Owner",
 				"name": "Owner A"
 			},
 			{
 				"_bramble_id": "5",
+				"_bramble__typename": "Owner",
 				"name": "Owner B"
 			},
 			{
 				"_bramble_id": "6",
+				"_bramble__typename": "Owner",
 				"name": "Owner C"
 			}
 		]`)
@@ -494,25 +540,31 @@ func TestMergeExecutionResults(t *testing.T) {
 			"gizmos": [
 				{
 					"_bramble_id": "1",
+					"_bramble__typename": "Gizmo",
 					"color": "RED",
 					"owner": {
 						"_bramble_id": "4",
+						"_bramble__typename": "Owner",
 						"name": "Owner A"
 					}
 				},
 				{
 					"_bramble_id": "2",
+					"_bramble__typename": "Gizmo",
 					"color": "GREEN",
 					"owner": {
 						"_bramble_id": "5",
+						"_bramble__typename": "Owner",
 						"name": "Owner B"
 					}
 				},
 				{
 					"_bramble_id": "3",
+					"_bramble__typename": "Gizmo",
 					"color": "BLUE",
 					"owner": {
 						"_bramble_id": "6",
+						"_bramble__typename": "Owner",
 						"name": "Owner C"
 					}
 				}
@@ -527,12 +579,13 @@ func TestMergeExecutionResults(t *testing.T) {
 		inputMapA := jsonToInterfaceMap(`{
 			"gizmo": {
 				"_bramble_id": "1",
+				"_bramble__typename": "Gizmo",
 				"gadgets": [
 					[
-						{"_bramble_id": "GADGET1", "details": { "owner": {"_bramble_id": "OWNER1" }}}
+						{"_bramble_id": "GADGET1", "_bramble__typename": "Gadget", "details": { "owner": {"_bramble_id": "OWNER1", "_bramble__typename": "Owner" }}}
 					],
 					[
-						{"_bramble_id": "GADGET2", "details": null}
+						{"_bramble_id": "GADGET2", "_bramble__typename": "Gadget", "details": null}
 					]
 				]
 			}
@@ -547,6 +600,7 @@ func TestMergeExecutionResults(t *testing.T) {
 		inputMapB := jsonToInterfaceSlice(`[
 			{
 				"_bramble_id": "OWNER1",
+				"_bramble__typename": "Owner",
 				"name": "Alice"
 			}
 		]`)
@@ -566,9 +620,11 @@ func TestMergeExecutionResults(t *testing.T) {
 					[
 						{
 							"_bramble_id": "GADGET1",
+							"_bramble__typename": "Gadget",
 							"details": {
 								"owner": {
 									"_bramble_id": "OWNER1",
+									"_bramble__typename": "Owner",
 									"name": "Alice"
 								}
 							}
@@ -577,11 +633,13 @@ func TestMergeExecutionResults(t *testing.T) {
 					[
 						{
 							"_bramble_id": "GADGET2",
+							"_bramble__typename": "Gadget",
 							"details": null
 						}
 					]
 				],
-				"_bramble_id": "1"
+				"_bramble_id": "1",
+				"_bramble__typename": "Gizmo"
 			}
 		}`)
 

--- a/execution_test.go
+++ b/execution_test.go
@@ -3185,6 +3185,7 @@ func TestQueryWithAbstractType(t *testing.T) {
 							"foos": [
 								{
 									"_bramble_id": "1",
+									"_bramble__typename": "Baz",
 									"id": "1"
 								},
 								{

--- a/execution_test.go
+++ b/execution_test.go
@@ -213,7 +213,7 @@ func TestFederatedQueryFragmentSpreads(t *testing.T) {
 						"snapshot": {
 							"id": "100",
 							"name": "foo",
-							"gizmos": [{ "_bramble_id": "GIZMO1", "id": "GIZMO1" }],
+							"gizmos": [{ "_bramble_id": "GIZMO1", "id": "GIZMO1", "_bramble__typename": "Gizmo" }],
 							"_bramble__typename": "GizmoImplementation"
 						}
 					}
@@ -225,7 +225,7 @@ func TestFederatedQueryFragmentSpreads(t *testing.T) {
 						"snapshot": {
 							"id": "100",
 							"name": "foo",
-							"gadgets": [{ "_bramble_id": "GADGET1", "id": "GADGET1" }],
+							"gadgets": [{ "_bramble_id": "GADGET1", "id": "GADGET1", "_bramble__typename": "Gadget" }],
 							"_bramble__typename": "GadgetImplementation"
 						}
 					}
@@ -239,13 +239,13 @@ func TestFederatedQueryFragmentSpreads(t *testing.T) {
 							{
 								"id": "100",
 								"name": "foo",
-								"gadgets": [{ "_bramble_id": "GADGET1", "id": "GADGET1" }],
+								"gadgets": [{ "_bramble_id": "GADGET1", "id": "GADGET1", "_bramble__typename": "Gadget" }],
 								"_bramble__typename": "GadgetImplementation"
 							},
 							{
 								"id": "100",
 								"name": "foo",
-								"gizmos": [{ "_bramble_id": "GIZMO1", "id": "GIZMO1" }],
+								"gizmos": [{ "_bramble_id": "GIZMO1", "id": "GIZMO1", "_bramble__typename": "Gizmo" }],
 								"_bramble__typename": "GizmoImplementation"
 							}
 						]
@@ -287,6 +287,7 @@ func TestFederatedQueryFragmentSpreads(t *testing.T) {
 					"data": {
 						"_0": {
 							"_bramble_id": "GIZMO1",
+							"_bramble__typename": "Gizmo",
 							"id": "GIZMO1",
 							"name": "Gizmo #1"
 						}
@@ -299,6 +300,7 @@ func TestFederatedQueryFragmentSpreads(t *testing.T) {
 						"_result": [
 							{
 								"_bramble_id": "GADGET1",
+								"_bramble__typename": "Gadget",
 								"id": "GADGET1",
 								"name": "Gadget #1",
 								"agents": [
@@ -672,6 +674,7 @@ func TestQueryExecutionMultipleServices(t *testing.T) {
 						"data": {
 							"movie": {
 								"_bramble_id": "1",
+								"_bramble__typename": "Movie",
 								"id": "1",
 								"title": "Test title"
 							}
@@ -696,6 +699,7 @@ func TestQueryExecutionMultipleServices(t *testing.T) {
 						"data": {
 							"_0": {
 								"_bramble_id": "1",
+								"_bramble__typename": "Movie",
 								"id": "1",
 								"release": 2007
 							}
@@ -742,6 +746,7 @@ func TestQueryExecutionServiceTimeout(t *testing.T) {
 						"data": {
 							"movie": {
 								"_bramble_id": "1",
+								"_bramble__typename": "Movie",
 								"id": "1",
 								"title": "Test title"
 							}
@@ -768,6 +773,7 @@ func TestQueryExecutionServiceTimeout(t *testing.T) {
 						"data": {
 							"_0": {
 								"_bramble_id": "1",
+								"_bramble__typename": "Movie",
 								"id": "1",
 								"release": 2007,
 								"slowField": "very slow field"
@@ -803,7 +809,7 @@ func TestQueryExecutionServiceTimeout(t *testing.T) {
 					{Line: 5, Column: 5},
 				},
 				Extensions: map[string]interface{}{
-					"selectionSet": "{ slowField _bramble_id: id }",
+					"selectionSet": "{ slowField _bramble_id: id _bramble__typename: __typename }",
 				},
 			},
 		},
@@ -1030,6 +1036,7 @@ func TestQueryWithArrayBoundaryFieldsAndMultipleChildrenSteps(t *testing.T) {
 						"data": {
 							"randomMovie": {
 									"_bramble_id": "1",
+									"_bramble__typename": "Movie",
 									"id": "1",
 									"title": "Movie 1"
 							}
@@ -1040,9 +1047,9 @@ func TestQueryWithArrayBoundaryFieldsAndMultipleChildrenSteps(t *testing.T) {
 						w.Write([]byte(`{
 						"data": {
 							"_result": [
-								{ "_bramble_id": "2", "id": "2", "title": "Movie 2" },
-								{ "_bramble_id": "3", "id": "3", "title": "Movie 3" },
-								{ "_bramble_id": "4", "id": "4", "title": "Movie 4" }
+								{ "_bramble_id": "2", "_bramble__typename": "Movie", "id": "2", "title": "Movie 2" },
+								{ "_bramble_id": "3", "_bramble__typename": "Movie", "id": "3", "title": "Movie 3" },
+								{ "_bramble_id": "4", "_bramble__typename": "Movie", "id": "4", "title": "Movie 4" }
 							]
 						}
 					}
@@ -1067,10 +1074,11 @@ func TestQueryWithArrayBoundaryFieldsAndMultipleChildrenSteps(t *testing.T) {
 							"_result": [
 								{
 									"_bramble_id": "1",
+									"_bramble__typename": "Movie",
 									"compTitles": [
-										{"_bramble_id": "2", "id": "2"},
-										{"_bramble_id": "3", "id": "3"},
-										{"_bramble_id": "4", "id": "4"}
+										{"_bramble_id": "2", "_bramble__typename": "Movie", "id": "2"},
+										{"_bramble_id": "3", "_bramble__typename": "Movie", "id": "3"},
+										{"_bramble_id": "4", "_bramble__typename": "Movie", "id": "4"}
 									]
 								}
 							]
@@ -1135,15 +1143,18 @@ func TestQueryWithBoundaryFieldsAndNullsAboveInsertionPoint(t *testing.T) {
 					response := jsonToInterfaceMap(`{
 						"data": {
 							"ns": {
+								"_bramble__typename": "Namespace",
 								"movies": [
 									{
 										"_bramble_id": "MOVIE1",
+										"_bramble__typename": "Movie",
 										"id": "MOVIE1",
 										"title": "Movie #1",
-										"director": { "_bramble_id": "DIRECTOR1", "id": "DIRECTOR1" }
+										"director": { "_bramble_id": "DIRECTOR1", "_bramble__typename": "Person", "id": "DIRECTOR1" }
 									},
 									{
 										"_bramble_id": "MOVIE2",
+										"_bramble__typename": "Movie",
 										"id": "MOVIE2",
 										"title": "Movie #2",
 										"director": null
@@ -1174,6 +1185,7 @@ func TestQueryWithBoundaryFieldsAndNullsAboveInsertionPoint(t *testing.T) {
 							"data": {
 								"_0": {
 									"_bramble_id": "DIRECTOR1",
+									"_bramble__typename": "Person",
 									"name": "David Fincher"
 								}
 							}
@@ -1237,14 +1249,17 @@ func TestNestingNullableBoundaryTypes(t *testing.T) {
 									"tastyGizmos": [
 										{
 											"_bramble_id": "beehasknees",
+											"_bramble__typename": "Gizmo",
 											"id": "beehasknees"
 										},
 										{
 											"_bramble_id": "umlaut",
+											"_bramble__typename": "Gizmo",
 											"id": "umlaut"
 										},
 										{
 											"_bramble_id": "probanana",
+											"_bramble__typename": "Gizmo",
 											"id": "probanana"
 										}
 									]
@@ -1338,14 +1353,17 @@ func TestNestingNullableBoundaryTypes(t *testing.T) {
 									"tastyGizmos": [
 										{
 											"_bramble_id": "beehasknees",
+											"_bramble__typename": "Gizmo",
 											"id": "beehasknees"
 										},
 										{
 											"_bramble_id": "umlaut",
+											"_bramble__typename": "Gizmo",
 											"id": "umlaut"
 										},
 										{
 											"_bramble_id": "probanana",
+											"_bramble__typename": "Gizmo",
 											"id": "probanana"
 										}
 									]
@@ -1374,14 +1392,17 @@ func TestNestingNullableBoundaryTypes(t *testing.T) {
 								null,
 								{
 									"_bramble_id": "umlaut",
+									"_bramble__typename": "Gizmo",
 									"id": "umlaut",
 									"wizzle": null
 								},
 								{
 									"_bramble_id": "probanana",
+									"_bramble__typename": "Gizmo",
 									"id": "probanana",
 									"wizzle": {
 										"_bramble_id": "bananawizzle",
+										"_bramble__typename": "Wizzle",
 										"id": "bananawizzle"
 									}
 								}
@@ -1405,6 +1426,7 @@ func TestNestingNullableBoundaryTypes(t *testing.T) {
 							"_result": [
 								{
 									"_bramble_id": "bananawizzle",
+									"_bramble__typename": "Wizzle",
 									"id": "bananawizzle",
 									"bazingaFactor": 4
 								}
@@ -1596,9 +1618,9 @@ func TestQueryExecutionWithMultipleBoundaryQueries(t *testing.T) {
 					w.Write([]byte(`{
 						"data": {
 							"movies": [
-								{ "_bramble_id": "1", "id": "1", "title": "Test title 1" },
-								{ "_bramble_id": "2", "id": "2", "title": "Test title 2" },
-								{ "_bramble_id": "3", "id": "3", "title": "Test title 3" }
+								{ "_bramble_id": "1", "_bramble__typename": "Movie", "id": "1", "title": "Test title 1" },
+								{ "_bramble_id": "2", "_bramble__typename": "Movie", "id": "2", "title": "Test title 2" },
+								{ "_bramble_id": "3", "_bramble__typename": "Movie", "id": "3", "title": "Test title 3" }
 							]
 						}
 					}
@@ -1612,9 +1634,9 @@ func TestQueryExecutionWithMultipleBoundaryQueries(t *testing.T) {
 					json.NewDecoder(r.Body).Decode(&q)
 					w.Write([]byte(`{
 						"data": {
-							"_0": { "_bramble_id": "1", "id": "1", "release": 2007 },
-							"_1": { "_bramble_id": "2", "id": "2", "release": 2008 },
-							"_2": { "_bramble_id": "3", "id": "3", "release": 2009 }
+							"_0": { "_bramble_id": "1", "_bramble__typename": "Movie", "id": "1", "release": 2007 },
+							"_1": { "_bramble_id": "2", "_bramble__typename": "Movie", "id": "2", "release": 2008 },
+							"_2": { "_bramble_id": "3", "_bramble__typename": "Movie", "id": "3", "release": 2009 }
 						}
 					}
 					`))
@@ -1686,6 +1708,7 @@ func TestQueryExecutionMultipleServicesWithArray(t *testing.T) {
 							res += fmt.Sprintf(`
 								"_%d": {
 									"_bramble_id": "%s",
+									"_bramble__typename": "Movie",
 									"id": "%s",
 									"title": "title %s"
 								}`, i, id, id, id)
@@ -1696,6 +1719,7 @@ func TestQueryExecutionMultipleServicesWithArray(t *testing.T) {
 							"data": {
 								"movie": {
 									"_bramble_id": "%s",
+									"_bramble__typename": "Movie",
 									"id": "%s",
 									"title": "title %s"
 								}
@@ -1720,22 +1744,25 @@ func TestQueryExecutionMultipleServicesWithArray(t *testing.T) {
 						"data": {
 							"_0": {
 								"_bramble_id": "1",
+								"_bramble__typename": "Movie",
 								"id": "1",
 								"compTitles": [
 									{
 										"_bramble_id": "2",
+										"_bramble__typename": "Movie",
 										"id": "2",
 										"compTitles": [
-											{ "_bramble_id": "3", "id": "3" },
-											{ "_bramble_id": "4", "id": "4" }
+											{ "_bramble_id": "3", "_bramble__typename": "Movie", "id": "3" },
+											{ "_bramble_id": "4", "_bramble__typename": "Movie", "id": "4" }
 										]
 									},
 									{
 										"_bramble_id": "3",
+										"_bramble__typename": "Movie",
 										"id": "3",
 										"compTitles": [
-											{ "_bramble_id": "4", "id": "4" },
-											{ "_bramble_id": "5", "id": "5" }
+											{ "_bramble_id": "4", "_bramble__typename": "Movie", "id": "4" },
+											{ "_bramble_id": "5", "_bramble__typename": "Movie", "id": "5" }
 										]
 									}
 								]
@@ -1884,6 +1911,7 @@ func TestQueryExecutionMultipleServicesWithNestedArrays(t *testing.T) {
 						res += fmt.Sprintf(`
 								"_%d": {
 									"_bramble_id": "%s",
+									"_bramble__typename": "Movie",
 									"id": "%s",
 									"title": "title %s"
 								}`, i, id, id, id)
@@ -1894,6 +1922,7 @@ func TestQueryExecutionMultipleServicesWithNestedArrays(t *testing.T) {
 							"data": {
 								"movie": {
 									"_bramble_id": "%s",
+									"_bramble__typename": "Movie",
 									"id": "%s",
 									"title": "title %s"
 								}
@@ -1918,14 +1947,17 @@ func TestQueryExecutionMultipleServicesWithNestedArrays(t *testing.T) {
 					"data": {
 						"_0": {
 							"_bramble_id": "1",
+							"_bramble__typename": "Movie",
 							"id": "1",
 							"compTitles": [[
 								{
 									"_bramble_id": "2",
+									"_bramble__typename": "Movie",
 									"id": "2"
 								},
 								{
 									"_bramble_id": "3",
+									"_bramble__typename": "Movie",
 									"id": "3"
 								}
 							]]
@@ -1987,6 +2019,7 @@ func TestQueryExecutionEmptyBoundaryResponse(t *testing.T) {
 						"data": {
 							"movie": {
 								"_bramble_id": "1",
+								"_bramble__typename": "Movie",
 								"id": "1",
 								"title": "Test title"
 							}
@@ -2121,18 +2154,22 @@ func TestQueryExecutionWithInputObject(t *testing.T) {
 							otherMovie(arg: {id: "2", title: "another title"}) {
 								title
 								_bramble_id: id
+								_bramble__typename: __typename
 							}
 							_bramble_id: id
+							_bramble__typename: __typename
 						}
 					}`, q["query"])
 					w.Write([]byte(`{
 						"data": {
 							"movie": {
 								"_bramble_id": "1",
+								"_bramble__typename": "Movie",
 								"id": "1",
 								"title": "Test title",
 								"otherMovie": {
 									"_bramble_id": "2",
+									"_bramble__typename": "Movie",
 									"title": "another title"
 								}
 							}
@@ -2157,6 +2194,7 @@ func TestQueryExecutionWithInputObject(t *testing.T) {
 						"data": {
 							"_0": {
 								"_bramble_id": "1",
+								"_bramble__typename": "Movie",
 								"id": "1",
 								"release": 2007
 							}
@@ -2209,6 +2247,7 @@ func TestQueryExecutionMultipleObjects(t *testing.T) {
 						"data": {
 							"movie": {
 								"_bramble_id": "1",
+								"_bramble__typename": "Movie",
 								"id": "1",
 								"title": "Test title"
 							}
@@ -2235,8 +2274,8 @@ func TestQueryExecutionMultipleObjects(t *testing.T) {
 						w.Write([]byte(`{
 							"data": {
 								"movies": [
-									{ "_bramble_id": "1", "id": "1", "release": 2007 },
-									{ "_bramble_id": "2", "id": "2", "release": 2018 }
+									{ "_bramble_id": "1", "_bramble__typename": "Movie", "id": "1", "release": 2007 },
+									{ "_bramble_id": "2", "_bramble__typename": "Movie", "id": "2", "release": 2018 }
 								]
 							}
 						}
@@ -2246,6 +2285,7 @@ func TestQueryExecutionMultipleObjects(t *testing.T) {
 							"data": {
 								"_0": {
 									"_bramble_id": "1",
+									"_bramble__typename": "Movie",
 									"id": "1",
 									"release": 2007
 								}
@@ -2366,6 +2406,7 @@ func TestQueryExecutionMultipleServicesWithSkipFalseDirectives(t *testing.T) {
 						"data": {
 							"movie": {
 								"_bramble_id": "1",
+								"_bramble__typename": "Movie",
 								"id": "1"
 							}
 						}
@@ -2391,6 +2432,7 @@ func TestQueryExecutionMultipleServicesWithSkipFalseDirectives(t *testing.T) {
 						"data": {
 							"_0": {
 								"_bramble_id": "1",
+								"_bramble__typename": "Movie",
 								"id": "1",
 								"title": "no soup for you",
 								"gizmo": {
@@ -2515,6 +2557,7 @@ func TestQueryExecutionMultipleServicesWithIncludeTrueDirectives(t *testing.T) {
 						"data": {
 							"movie": {
 								"_bramble_id": "1",
+								"_bramble__typename": "Movie",
 								"id": "1"
 							}
 						}
@@ -2540,6 +2583,7 @@ func TestQueryExecutionMultipleServicesWithIncludeTrueDirectives(t *testing.T) {
 						"data": {
 							"_0": {
 								"_bramble_id": "1",
+								"_bramble__typename": "Movie",
 								"id": "1",
 								"title": "yada yada yada",
 								"gizmo": {
@@ -2601,12 +2645,13 @@ func TestMutationExecution(t *testing.T) {
 				handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					var q map[string]string
 					json.NewDecoder(r.Body).Decode(&q)
-					assertQueriesEqual(t, schema1, `mutation { updateTitle(id: "2", title: "New title") { title _bramble_id: id } }`, q["query"])
+					assertQueriesEqual(t, schema1, `mutation { updateTitle(id: "2", title: "New title") { title _bramble_id: id _bramble__typename: __typename } }`, q["query"])
 
 					w.Write([]byte(`{
 						"data": {
 							"updateTitle": {
 								"_bramble_id": "2",
+								"_bramble__typename": "Movie",
 								"id": "2",
 								"title": "New title"
 							}
@@ -2629,6 +2674,7 @@ func TestMutationExecution(t *testing.T) {
 						"data": {
 							"_0": {
 								"_bramble_id": "2",
+								"_bramble__typename": "Movie",
 								"id": "2",
 								"release": 2007
 							}
@@ -2695,6 +2741,7 @@ func TestQueryExecutionWithUnions(t *testing.T) {
 							"data": {
 								"_0": {
 									"_bramble_id": "2",
+									"_bramble__typename": "Person",
 									"pet": {
 										"name": "felix",
 										"age": 2,
@@ -2724,6 +2771,7 @@ func TestQueryExecutionWithUnions(t *testing.T) {
 						"data": {
 							"person": {
 								"_bramble_id": "2",
+								"_bramble__typename": "Person",
 								"name": "Bob"
 							}
 						}
@@ -2800,6 +2848,7 @@ func TestQueryExecutionWithNamespaces(t *testing.T) {
 							"data": {
 								"_0": {
 									"_bramble_id": "CA7",
+									"_bramble__typename": "Cat",
 									"name": "Felix"
 								}
 							}
@@ -2851,6 +2900,7 @@ func TestQueryExecutionWithNamespaces(t *testing.T) {
 								"cats": {
 									"searchCat": {
 										"_bramble_id": "CA7",
+										"_bramble__typename": "Cat",
 										"id": "CA7"
 									}
 								}
@@ -2946,6 +2996,7 @@ func TestQueryWithBoundaryFields(t *testing.T) {
 						"data": {
 							"movie": {
 								"_bramble_id": "1",
+								"_bramble__typename": "Movie",
 								"id": "1",
 								"title": "Test title"
 							}
@@ -2970,6 +3021,7 @@ func TestQueryWithBoundaryFields(t *testing.T) {
 						"data": {
 							"_0": {
 								"_bramble_id": "1",
+								"_bramble__typename": "Movie",
 								"id": "1",
 								"release": 2007
 							}
@@ -3068,16 +3120,19 @@ func TestQueryWithArrayBoundaryFields(t *testing.T) {
 							"randomMovies": [
 								{
 									"_bramble_id": "1",
+									"_bramble__typename": "Movie",
 									"id": "1",
 									"title": "Movie 1"
 								},
 								{
 									"_bramble_id": "2",
+									"_bramble__typename": "Movie",
 									"id": "2",
 									"title": "Movie 2"
 								},
 								{
 									"_bramble_id": "3",
+									"_bramble__typename": "Movie",
 									"id": "3",
 									"title": "Movie 3"
 								}
@@ -3104,16 +3159,19 @@ func TestQueryWithArrayBoundaryFields(t *testing.T) {
 							"_result": [
 								{
 									"_bramble_id": "1",
+									"_bramble__typename": "Movie",
 									"id": "1",
 									"release": 2007
 								},
 								{
 									"_bramble_id": "2",
+									"_bramble__typename": "Movie",
 									"id": "2",
 									"release": 2008
 								},
 								{
 									"_bramble_id": "3",
+									"_bramble__typename": "Movie",
 									"id": "3",
 									"release": 2009
 								}
@@ -3189,6 +3247,7 @@ func TestQueryWithAbstractType(t *testing.T) {
 									"id": "1"
 								},
 								{
+									"_bramble__typename": "Bar",
 									"id": "2",
 									"bar": "bar"
 								}
@@ -3216,6 +3275,7 @@ func TestQueryWithAbstractType(t *testing.T) {
 						"data": {
 							"_0": {
 								"_bramble_id": "1",
+								"_bramble__typename": "Baz",
 								"id": "1",
 								"baz": "baz"
 							}

--- a/merge_test.go
+++ b/merge_test.go
@@ -105,7 +105,7 @@ func TestMergeTwoSchemasNoBoundaryTypes(t *testing.T) {
 	fixture.CheckSuccess(t)
 }
 
-func TestMergeTwoSchemasWithCollindingInterface(t *testing.T) {
+func TestMergeTwoSchemasWithCollidingInterface(t *testing.T) {
 	fixture := MergeTestFixture{
 		Input1: `
 			interface Named {

--- a/merge_test.go
+++ b/merge_test.go
@@ -772,7 +772,7 @@ func TestRejectsConflictingMutations(t *testing.T) {
 	fixture.CheckError(t)
 }
 
-func TestMergeCustomnScalars(t *testing.T) {
+func TestMergeCustomScalars(t *testing.T) {
 	fixture := MergeTestFixture{
 		Input1:   `scalar MyCustomScalar`,
 		Input2:   `scalar MyCustomScalar`,

--- a/plan.go
+++ b/plan.go
@@ -173,7 +173,6 @@ func extractSelectionSet(ctx *PlanningContext, insertionPoint []string, parentTy
 			if err != nil {
 				return nil, nil, err
 			}
-			selectionSet = append(selectionSet, &ast.Field{Alias: "_bramble__typename", Name: "__typename", Definition: &ast.FieldDefinition{Name: "__typename", Type: ast.NamedType("String", nil)}})
 			inlineFragment := *selection
 			inlineFragment.SelectionSet = selectionSet
 			selectionSetResult = append(selectionSetResult, &inlineFragment)
@@ -189,7 +188,6 @@ func extractSelectionSet(ctx *PlanningContext, insertionPoint []string, parentTy
 			if err != nil {
 				return nil, nil, err
 			}
-			selectionSet = append(selectionSet, &ast.Field{Alias: "_bramble__typename", Name: "__typename", Definition: &ast.FieldDefinition{Name: "__typename", Type: ast.NamedType("String", nil)}})
 			inlineFragment := ast.InlineFragment{
 				TypeCondition: selection.Definition.TypeCondition,
 				SelectionSet:  selectionSet,
@@ -264,7 +262,10 @@ func extractSelectionSet(ctx *PlanningContext, insertionPoint []string, parentTy
 	} else if parentType != queryObjectName && parentType != mutationObjectName && ctx.IsBoundary[parentType] {
 		// Otherwise, add an id selection to all boundary types
 		if idDef := parentDef.Fields.ForName(IdFieldName); idDef != nil {
-			selectionSetResult = append(selectionSetResult, &ast.Field{Alias: "_bramble_id", Name: IdFieldName, Definition: idDef})
+			selectionSetResult = append(selectionSetResult,
+				&ast.Field{Alias: "_bramble_id", Name: IdFieldName, Definition: idDef},
+				&ast.Field{Alias: "_bramble__typename", Name: "__typename", Definition: &ast.FieldDefinition{Name: "__typename", Type: ast.NamedType("String", nil)}},
+			)
 		}
 	}
 	return selectionSetResult, childrenStepsResult, nil

--- a/plan_test.go
+++ b/plan_test.go
@@ -13,7 +13,7 @@ func TestQueryPlanA(t *testing.T) {
 		  {
 			"ServiceURL": "A",
 			"ParentType": "Query",
-			"SelectionSet": "{ movies { id title _bramble_id: id } }",
+			"SelectionSet": "{ movies { id title _bramble_id: id _bramble__typename: __typename } }",
 			"InsertionPoint": null,
 			"Then": null
 		  }
@@ -29,13 +29,13 @@ func TestQueryPlanAB1(t *testing.T) {
 		  {
 			"ServiceURL": "A",
 			"ParentType": "Query",
-			"SelectionSet": "{ movies { id _bramble_id: id } }",
+			"SelectionSet": "{ movies { id _bramble_id: id _bramble__typename: __typename } }",
 			"InsertionPoint": null,
 			"Then": [
 			  {
 				"ServiceURL": "B",
 				"ParentType": "Movie",
-				"SelectionSet": "{ compTitles(limit: 42) { id _bramble_id: id } _bramble_id: id }",
+				"SelectionSet": "{ compTitles(limit: 42) { id _bramble_id: id _bramble__typename: __typename } _bramble_id: id _bramble__typename: __typename }",
 				"InsertionPoint": ["movies"],
 				"Then": null
 			  }
@@ -53,13 +53,13 @@ func TestQueryPlanAB2(t *testing.T) {
 		  {
 			"ServiceURL": "A",
 			"ParentType": "Query",
-			"SelectionSet": "{ movies { id _bramble_id: id } }",
+			"SelectionSet": "{ movies { id _bramble_id: id _bramble__typename: __typename } }",
 			"InsertionPoint": null,
 			"Then": [
 			  {
 				"ServiceURL": "B",
 				"ParentType": "Movie",
-				"SelectionSet": "{ compTitles(limit: 42) { id compTitles(limit: 666) { id _bramble_id: id } _bramble_id: id } _bramble_id: id }",
+				"SelectionSet": "{ compTitles(limit: 42) { id compTitles(limit: 666) { id _bramble_id: id _bramble__typename: __typename } _bramble_id: id _bramble__typename: __typename } _bramble_id: id _bramble__typename: __typename }",
 				"InsertionPoint": ["movies"],
 				"Then": null
 			  }
@@ -77,19 +77,19 @@ func TestQueryPlanABA1(t *testing.T) {
 		  {
 			"ServiceURL": "A",
 			"ParentType": "Query",
-			"SelectionSet": "{ movies { id _bramble_id: id } }",
+			"SelectionSet": "{ movies { id _bramble_id: id _bramble__typename: __typename } }",
 			"InsertionPoint": null,
 			"Then": [
 			  {
 				"ServiceURL": "B",
 				"ParentType": "Movie",
-				"SelectionSet": "{ compTitles(limit: 42) { id _bramble_id: id } _bramble_id: id }",
+				"SelectionSet": "{ compTitles(limit: 42) { id _bramble_id: id _bramble__typename: __typename } _bramble_id: id _bramble__typename: __typename }",
 				"InsertionPoint": ["movies"],
 				"Then": [
 				  {
 					"ServiceURL": "A",
 					"ParentType": "Movie",
-					"SelectionSet": "{ title _bramble_id: id }",
+					"SelectionSet": "{ title _bramble_id: id _bramble__typename: __typename }",
 					"InsertionPoint": ["movies", "compTitles"],
 					"Then": null
 				  }
@@ -109,26 +109,26 @@ func TestQueryPlanABA2(t *testing.T) {
 		  {
 			"ServiceURL": "A",
 			"ParentType": "Query",
-			"SelectionSet": "{ movies { id _bramble_id: id } }",
+			"SelectionSet": "{ movies { id _bramble_id: id _bramble__typename: __typename } }",
 			"InsertionPoint": null,
 			"Then": [
 			  {
 				"ServiceURL": "B",
 				"ParentType": "Movie",
-				"SelectionSet": "{ compTitles(limit: 42) { id compTitles(limit: 666) { id _bramble_id: id } _bramble_id: id } _bramble_id: id }",
+				"SelectionSet": "{ compTitles(limit: 42) { id compTitles(limit: 666) { id _bramble_id: id _bramble__typename: __typename } _bramble_id: id _bramble__typename: __typename } _bramble_id: id _bramble__typename: __typename }",
 				"InsertionPoint": ["movies"],
 				"Then": [
 				  {
 					"ServiceURL": "A",
 					"ParentType": "Movie",
-					"SelectionSet": "{ title _bramble_id: id }",
+					"SelectionSet": "{ title _bramble_id: id _bramble__typename: __typename }",
 					"InsertionPoint": ["movies", "compTitles", "compTitles"],
 					"Then": null
 				  },
 				  {
 					"ServiceURL": "A",
 					"ParentType": "Movie",
-					"SelectionSet": "{ title _bramble_id: id }",
+					"SelectionSet": "{ title _bramble_id: id _bramble__typename: __typename }",
 					"InsertionPoint": ["movies", "compTitles"],
 					"Then": null
 				  }
@@ -148,7 +148,7 @@ func TestQueryPlanAC(t *testing.T) {
 		  {
 			"ServiceURL": "A",
 			"ParentType": "Query",
-			"SelectionSet": "{ movies { id title _bramble_id: id } }",
+			"SelectionSet": "{ movies { id title _bramble_id: id _bramble__typename: __typename } }",
 			"InsertionPoint": null,
 			"Then": null
 		  },
@@ -171,13 +171,13 @@ func TestQueryPlanWithAliases(t *testing.T) {
 		  {
 			"ServiceURL": "A",
 			"ParentType": "Query",
-			"SelectionSet": "{ a1: movies { a2: id a3: title _bramble_id: id } }",
+			"SelectionSet": "{ a1: movies { a2: id a3: title _bramble_id: id _bramble__typename: __typename } }",
 			"InsertionPoint": null,
 			"Then": [
 			  {
 				"ServiceURL": "B",
 				"ParentType": "Movie",
-				"SelectionSet": "{ a4: compTitles(limit: 42) { a5: id _bramble_id: id } _bramble_id: id }",
+				"SelectionSet": "{ a4: compTitles(limit: 42) { a5: id _bramble_id: id _bramble__typename: __typename } _bramble_id: id _bramble__typename: __typename }",
 				"InsertionPoint": ["a1"],
 				"Then": null
 			  }
@@ -195,7 +195,7 @@ func TestQueryPlanWithTypename(t *testing.T) {
 			  {
 				"ServiceURL": "A",
 				"ParentType": "Query",
-				"SelectionSet": "{ movies { id title __typename _bramble_id: id } }",
+				"SelectionSet": "{ movies { id title __typename _bramble_id: id _bramble__typename: __typename } }",
 				"InsertionPoint": null,
 				"Then": null
 			  },
@@ -241,7 +241,7 @@ func TestQueryPlanOptionalArgument(t *testing.T) {
 		  {
 			"ServiceURL": "A",
 			"ParentType": "Query",
-			"SelectionSet": "{ movies { id title(language: French) _bramble_id: id } }",
+			"SelectionSet": "{ movies { id title(language: French) _bramble_id: id _bramble__typename: __typename } }",
 			"InsertionPoint": null,
 			"Then": null
 		  }
@@ -264,7 +264,7 @@ func TestQueryPlanInlineFragment(t *testing.T) {
 			{
 				"ServiceURL": "A",
 				"ParentType": "Query",
-				"SelectionSet": "{ movies { ... on Movie { id title(language: French) _bramble_id: id _bramble__typename: __typename } _bramble_id: id } }",
+				"SelectionSet": "{ movies { ... on Movie { id title(language: French) _bramble_id: id _bramble__typename: __typename } _bramble_id: id _bramble__typename: __typename } }",
 				"InsertionPoint": null,
 				"Then": null
 			}
@@ -288,7 +288,7 @@ func TestQueryPlanInlineFragmentDoesNotDuplicateTypename(t *testing.T) {
 			{
 				"ServiceURL": "A",
 				"ParentType": "Query",
-				"SelectionSet": "{ movies { ... on Movie { __typename id title(language: French) _bramble_id: id _bramble__typename: __typename } _bramble_id: id } }",
+				"SelectionSet": "{ movies { ... on Movie { __typename id title(language: French) _bramble_id: id _bramble__typename: __typename } _bramble_id: id _bramble__typename: __typename } }",
 				"InsertionPoint": null,
 				"Then": null
 			}
@@ -314,13 +314,13 @@ func TestQueryPlanInlineFragmentPlan(t *testing.T) {
 			{
 				"ServiceURL": "A",
 				"ParentType": "Query",
-				"SelectionSet": "{ movies { ... on Movie { id title(language: French) _bramble_id: id _bramble__typename: __typename } _bramble_id: id } }",
+				"SelectionSet": "{ movies { ... on Movie { id title(language: French) _bramble_id: id _bramble__typename: __typename } _bramble_id: id _bramble__typename: __typename } }",
 				"InsertionPoint": null,
 				"Then": [
 					{
 						"ServiceURL": "B",
 						"ParentType": "Movie",
-						"SelectionSet": "{ compTitles(limit: 42) { id _bramble_id: id } _bramble_id: id }",
+						"SelectionSet": "{ compTitles(limit: 42) { id _bramble_id: id _bramble__typename: __typename } _bramble_id: id _bramble__typename: __typename }",
 						"InsertionPoint": ["movies"],
 						"Then": null
 					}
@@ -347,7 +347,7 @@ func TestQueryPlanFragmentSpread1(t *testing.T) {
 			{
 				"ServiceURL": "A",
 				"ParentType": "Query",
-				"SelectionSet": "{ movies { ... on Movie { id title(language: French) _bramble_id: id _bramble__typename: __typename } _bramble_id: id } }",
+				"SelectionSet": "{ movies { ... on Movie { id title(language: French) _bramble_id: id _bramble__typename: __typename } _bramble_id: id _bramble__typename: __typename } }",
 				"InsertionPoint": null,
 				"Then": null
 			}
@@ -373,7 +373,7 @@ func TestQueryPlanFragmentSpread2(t *testing.T) {
 			{
 				"ServiceURL": "A",
 				"ParentType": "Query",
-				"SelectionSet": "{ movies { id title(language: French) _bramble_id: id } }",
+				"SelectionSet": "{ movies { id title(language: French) _bramble_id: id _bramble__typename: __typename } }",
 				"InsertionPoint": null,
 				"Then": null
 			}
@@ -400,19 +400,19 @@ func TestQueryPlanCompleteDeepTraversal(t *testing.T) {
 			{
 				"ServiceURL": "A",
 				"ParentType": "Query",
-				"SelectionSet": "{ shop1 { name products { _bramble_id: id } } }",
+				"SelectionSet": "{ shop1 { name products { _bramble_id: id _bramble__typename: __typename } } }",
 				"InsertionPoint": null,
 				"Then": [
 					{
 					"ServiceURL": "B",
 					"ParentType": "Product",
-					"SelectionSet": "{ name collection { _bramble_id: id } _bramble_id: id }",
+					"SelectionSet": "{ name collection { _bramble_id: id _bramble__typename: __typename } _bramble_id: id _bramble__typename: __typename }",
 					"InsertionPoint": ["shop1", "products"],
 					"Then": [
 							{
 							"ServiceURL": "C",
 							"ParentType": "Collection",
-							"SelectionSet": "{ name _bramble_id: id }",
+							"SelectionSet": "{ name _bramble_id: id _bramble__typename: __typename }",
 							"InsertionPoint": ["shop1", "products", "collection"],
 							"Then": null
 							}
@@ -442,13 +442,13 @@ func TestQueryPlanMergeInsertionPointSteps(t *testing.T) {
 			{
 				"ServiceURL": "A",
 				"ParentType": "Query",
-				"SelectionSet": "{ shop1 { products { _bramble_id: id } products { _bramble_id: id } } }",
+				"SelectionSet": "{ shop1 { products { _bramble_id: id _bramble__typename: __typename } products { _bramble_id: id _bramble__typename: __typename } } }",
 				"InsertionPoint": null,
 				"Then": [
 					{
 					"ServiceURL": "B",
 					"ParentType": "Product",
-					"SelectionSet": "{ name _bramble_id: id name _bramble_id: id }",
+					"SelectionSet": "{ name _bramble_id: id _bramble__typename: __typename name _bramble_id: id _bramble__typename: __typename }",
 					"InsertionPoint": ["shop1", "products"],
 					"Then": null
 					}
@@ -506,7 +506,7 @@ func TestQueryPlanSkipDirective(t *testing.T) {
 		  {
 			"ServiceURL": "A",
 			"ParentType": "Query",
-			"SelectionSet": "{ movies { id title @skip(if: false) _bramble_id: id } }",
+			"SelectionSet": "{ movies { id title @skip(if: false) _bramble_id: id _bramble__typename: __typename } }",
 			"InsertionPoint": null,
 			"Then": null
 		  }
@@ -522,7 +522,7 @@ func TestQueryPlanIncludeDirective(t *testing.T) {
 		  {
 			"ServiceURL": "A",
 			"ParentType": "Query",
-			"SelectionSet": "{ movies { id title @include(if: true) _bramble_id: id } }",
+			"SelectionSet": "{ movies { id title @include(if: true) _bramble_id: id _bramble__typename: __typename } }",
 			"InsertionPoint": null,
 			"Then": null
 		  }
@@ -538,7 +538,7 @@ func TestQueryPlanSkipAndIncludeDirective(t *testing.T) {
 		  {
 			"ServiceURL": "A",
 			"ParentType": "Query",
-			"SelectionSet": "{ movies { id title @skip(if: false) @include(if: true) _bramble_id: id } }",
+			"SelectionSet": "{ movies { id title @skip(if: false) @include(if: true) _bramble_id: id _bramble__typename: __typename } }",
 			"InsertionPoint": null,
 			"Then": null
 		  }
@@ -554,13 +554,13 @@ func TestQueryPlanSkipAndIncludeDirectiveInChildStep(t *testing.T) {
 		  {
 			"ServiceURL": "A",
 			"ParentType": "Query",
-			"SelectionSet": "{ movies { id _bramble_id: id } }",
+			"SelectionSet": "{ movies { id _bramble_id: id _bramble__typename: __typename } }",
 			"InsertionPoint": null,
 			"Then": [
 			  {
 				"ServiceURL": "B",
 				"ParentType": "Movie",
-				"SelectionSet": "{ compTitles(limit: 42) { id @skip(if: false) @include(if: true) _bramble_id: id } _bramble_id: id }",
+				"SelectionSet": "{ compTitles(limit: 42) { id @skip(if: false) @include(if: true) _bramble_id: id _bramble__typename: __typename } _bramble_id: id _bramble__typename: __typename }",
 				"InsertionPoint": ["movies"],
 				"Then": null
 			  }
@@ -578,13 +578,13 @@ func TestQueryPlanSupportsAliasing(t *testing.T) {
         {
           "ServiceURL": "A",
           "ParentType": "Query",
-          "SelectionSet": "{ foo: movies { id aliasTitle: title _bramble_id: id } }",
+          "SelectionSet": "{ foo: movies { id aliasTitle: title _bramble_id: id _bramble__typename: __typename } }",
           "InsertionPoint": null,
           "Then": [
             {
               "ServiceURL": "B",
               "ParentType": "Movie",
-              "SelectionSet": "{ bar: compTitles(limit: 42) { id _bramble_id: id } _bramble_id: id }",
+              "SelectionSet": "{ bar: compTitles(limit: 42) { id _bramble_id: id _bramble__typename: __typename } _bramble_id: id _bramble__typename: __typename }",
               "InsertionPoint": [
                 "foo"
               ],
@@ -592,7 +592,7 @@ func TestQueryPlanSupportsAliasing(t *testing.T) {
                 {
                   "ServiceURL": "A",
                   "ParentType": "Movie",
-                  "SelectionSet": "{ compTitleAliasTitle: title _bramble_id: id }",
+                  "SelectionSet": "{ compTitleAliasTitle: title _bramble_id: id _bramble__typename: __typename }",
                   "InsertionPoint": [
                     "foo",
                     "bar"
@@ -614,7 +614,7 @@ func TestQueryPlanSupportsUnions(t *testing.T) {
         {
           "ServiceURL": "A",
           "ParentType": "Query",
-          "SelectionSet": "{ animals { ... on Dog { name _bramble__typename: __typename } ... on Cat { name _bramble__typename: __typename } ... on Snake { name _bramble__typename: __typename } _bramble__typename: __typename } }",
+          "SelectionSet": "{ animals { ... on Dog { name } ... on Cat { name } ... on Snake { name } _bramble__typename: __typename } }",
           "InsertionPoint": null,
           "Then": null
         }
@@ -662,13 +662,13 @@ func TestQueryPlanSupportsMutations(t *testing.T) {
 		  {
 			"ServiceURL": "A",
 			"ParentType": "Mutation",
-			"SelectionSet": "{ updateTitle(id: \"2\", title: \"New title\") { title _bramble_id: id } }",
+			"SelectionSet": "{ updateTitle(id: \"2\", title: \"New title\") { title _bramble_id: id _bramble__typename: __typename } }",
 			"InsertionPoint": null,
 			"Then": [
 			  {
 				"ServiceURL": "B",
 				"ParentType": "Movie",
-				"SelectionSet": "{ release _bramble_id: id }",
+				"SelectionSet": "{ release _bramble_id: id _bramble__typename: __typename }",
 				"InsertionPoint": [
 				  "updateTitle"
 				],
@@ -688,13 +688,13 @@ func TestQueryPlanWithPaginatedBoundaryType(t *testing.T) {
         {
           "ServiceURL": "A",
           "ParentType": "Query",
-          "SelectionSet": "{ foo { foos { cursor page { id name _bramble_id: id } } } }",
+          "SelectionSet": "{ foo { foos { cursor page { id name _bramble_id: id _bramble__typename: __typename } } } }",
           "InsertionPoint": null,
           "Then": [
 			{
 				"ServiceURL": "B",
 				"ParentType": "Foo",
-				"SelectionSet": "{ size _bramble_id: id }",
+				"SelectionSet": "{ size _bramble_id: id _bramble__typename: __typename }",
 				"InsertionPoint": [ "foo", "foos", "page" ],
 				"Then": null
 			}
@@ -781,13 +781,13 @@ func TestQueryPlanWithNestedNamespaces(t *testing.T) {
 		  {
 			"ServiceURL": "A",
 			"ParentType": "Mutation",
-			"SelectionSet": "{ firstLevel { secondLevel { movie { id compTitles { id _bramble_id: id } releases { date _bramble_id: id } _bramble_id: id } } } }",
+			"SelectionSet": "{ firstLevel { secondLevel { movie { id compTitles { id _bramble_id: id _bramble__typename: __typename } releases { date _bramble_id: id _bramble__typename: __typename } _bramble_id: id _bramble__typename: __typename } } } }",
 			"InsertionPoint": null,
 			"Then": [
 			  {
 				"ServiceURL": "B",
 				"ParentType": "CompTitle",
-				"SelectionSet": "{ score _bramble_id: id }",
+				"SelectionSet": "{ score _bramble_id: id _bramble__typename: __typename }",
 				"InsertionPoint": [
 				  "firstLevel",
 				  "secondLevel",
@@ -820,7 +820,7 @@ func TestQueryPlanNoUnnessecaryID(t *testing.T) {
 		  {
 			"ServiceURL": "A",
 			"ParentType": "Query",
-			"SelectionSet": "{ movies { title _bramble_id: id } }",
+			"SelectionSet": "{ movies { title _bramble_id: id _bramble__typename: __typename } }",
 			"InsertionPoint": null,
 			"Then": null
 		  }


### PR DESCRIPTION
I think there are two ways to fix this
a) a886f69b5fc7cd0dd2ab924e8477d21b61bb9d6a just assume if the _bramble_id is missing that it's not a boundary type
b) 2dcec5a23e7b3366c0bbc533ee90c2818f46b612 always ask for __typename and check the types before merging.

I'm not sure which one is the correct one.