### PR TITLE
Pass variables downstream

### DIFF
--- a/client.go
+++ b/client.go
@@ -159,9 +159,9 @@ type Request struct {
 }
 
 // NewRequest creates a new GraphQL requests from the provided body.
-func NewRequest(body string) *Request {
+func NewRequest(query string) *Request {
 	return &Request{
-		Query: body,
+		Query: query,
 	}
 }
 
@@ -172,6 +172,11 @@ func (r *Request) WithHeaders(headers http.Header) *Request {
 
 func (r *Request) WithOperationName(operationName string) *Request {
 	r.OperationName = operationName
+	return r
+}
+
+func (r *Request) WithVariables(variables map[string]interface{}) *Request {
+	r.Variables = variables
 	return r
 }
 

--- a/execution.go
+++ b/execution.go
@@ -459,7 +459,7 @@ func buildBoundaryQueryDocuments(ctx context.Context, schema *ast.Schema, step *
 			selections = append(selections, selection)
 			selectionIndex++
 		}
-		document := "{ " + strings.Join(selections, " ") + " }"
+		document := fmt.Sprintf("query %s { %s }", operation, strings.Join(selections, " "))
 		documents = append(documents, document)
 	}
 

--- a/execution.go
+++ b/execution.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/99designs/gqlgen/graphql"
 	"github.com/vektah/gqlparser/v2/ast"
 	"github.com/vektah/gqlparser/v2/gqlerror"
 	"golang.org/x/sync/errgroup"
@@ -93,17 +92,12 @@ func (q *queryExecution) Execute(queryPlan *QueryPlan) ([]executionResult, gqler
 func (q *queryExecution) executeRootStep(step *QueryPlanStep) error {
 	var document string
 
+	var variables map[string]interface{}
 	switch step.ParentType {
 	case queryObjectName, mutationObjectName:
-		document = formatDocument(q.ctx, q.schema, step.ParentType, step.SelectionSet)
+		document, variables = formatDocument(q.ctx, q.schema, step.ParentType, step.SelectionSet)
 	default:
 		return errors.New("expected mutation or query root step")
-	}
-
-	var variables map[string]interface{}
-	if graphql.HasOperationContext(q.ctx) {
-		operationContext := graphql.GetOperationContext(q.ctx)
-		variables = operationContext.Variables
 	}
 
 	var data map[string]interface{}

--- a/execution_helpers_test.go
+++ b/execution_helpers_test.go
@@ -53,7 +53,7 @@ func TestBuildBoundaryQueryDocuments(t *testing.T) {
 		Then:           nil,
 	}
 	expected := []string{`query operationName { _result: getOwners(ids: ["1", "2", "3"]) { _bramble_id: id name } }`}
-	ctx := testContextWithoutVariables(nil)
+	ctx := testContextWithoutVariables(&ast.OperationDefinition{Name: "operationName"})
 	docs, vars, err := buildBoundaryQueryDocuments(ctx, schema, step, ids, boundaryField, 1)
 	require.NoError(t, err)
 	require.Equal(t, expected, docs)
@@ -145,7 +145,7 @@ func TestBuildNonArrayBoundaryQueryDocuments(t *testing.T) {
 		Then:           nil,
 	}
 	expected := []string{`query name { _0: getOwner(id: "1") { _bramble_id: id name } _1: getOwner(id: "2") { _bramble_id: id name } _2: getOwner(id: "3") { _bramble_id: id name } }`}
-	ctx := testContextWithoutVariables(nil)
+	ctx := testContextWithoutVariables(&ast.OperationDefinition{Name: "name"})
 	docs, vars, err := buildBoundaryQueryDocuments(ctx, schema, step, ids, boundaryField, 10)
 	require.NoError(t, err)
 	require.Equal(t, expected, docs)
@@ -238,7 +238,7 @@ func TestBuildBatchedNonArrayBoundaryQueryDocuments(t *testing.T) {
 		Then:           nil,
 	}
 	expected := []string{`query op { _0: getOwner(id: "1") { _bramble_id: id name } _1: getOwner(id: "2") { _bramble_id: id name } }`, `query op { _2: getOwner(id: "3") { _bramble_id: id name } }`}
-	ctx := testContextWithoutVariables(nil)
+	ctx := testContextWithoutVariables(&ast.OperationDefinition{Name: "op"})
 	docs, vars, err := buildBoundaryQueryDocuments(ctx, schema, step, ids, boundaryField, 2)
 	require.NoError(t, err)
 	require.Equal(t, expected, docs)

--- a/execution_helpers_test.go
+++ b/execution_helpers_test.go
@@ -54,9 +54,51 @@ func TestBuildBoundaryQueryDocuments(t *testing.T) {
 	}
 	expected := []string{`query operationName { _result: getOwners(ids: ["1", "2", "3"]) { _bramble_id: id name } }`}
 	ctx := testContextWithoutVariables(nil)
-	docs, err := buildBoundaryQueryDocuments(ctx, "operationName", schema, step, ids, boundaryField, 1)
+	docs, vars, err := buildBoundaryQueryDocuments(ctx, schema, step, ids, boundaryField, 1)
 	require.NoError(t, err)
 	require.Equal(t, expected, docs)
+	require.Equal(t, (map[string]interface{})(nil), vars)
+}
+
+func TestBuildBoundaryQueryDocumentsWithVariables(t *testing.T) {
+	ddl := `
+		type Gizmo {
+			id: ID!
+			color: String!
+			owner: Owner
+		}
+
+		type Owner {
+			id: ID!
+			name(format: String): String!
+		}
+
+		type Query {
+			gizmos: [Gizmo!]!
+			getOwners(ids: [ID!]!): [Owner!]!
+		}
+	`
+	schema := gqlparser.MustLoadSchema(&ast.Source{Name: "fixture", Input: ddl})
+	boundaryField := BoundaryField{Field: "getOwners", Argument: "ids", Array: true}
+	ids := []string{"1", "2", "3"}
+	query := gqlparser.MustLoadQuery(schema, `query ($format: String) {
+		getOwners(ids: []) { _bramble_id: id name(format: $format) }
+	}`)
+
+	step := &QueryPlanStep{
+		ServiceURL:     "http://example.com:8080",
+		ServiceName:    "test",
+		ParentType:     "Gizmo",
+		SelectionSet:   query.Operations[0].SelectionSet[0].(*ast.Field).SelectionSet,
+		InsertionPoint: []string{"gizmos", "owner"},
+		Then:           nil,
+	}
+	expected := []string{`query ($format: String) { _result: getOwners(ids: ["1", "2", "3"]) { _bramble_id: id name(format: $format) } }`}
+	ctx := testContextWithVariables(map[string]interface{}{"format": "upper"}, query.Operations[0])
+	docs, vars, err := buildBoundaryQueryDocuments(ctx, schema, step, ids, boundaryField, 1)
+	require.NoError(t, err)
+	require.Equal(t, expected, docs)
+	require.Equal(t, map[string]interface{}{"format": "upper"}, vars)
 }
 
 func TestBuildNonArrayBoundaryQueryDocuments(t *testing.T) {
@@ -104,9 +146,52 @@ func TestBuildNonArrayBoundaryQueryDocuments(t *testing.T) {
 	}
 	expected := []string{`query name { _0: getOwner(id: "1") { _bramble_id: id name } _1: getOwner(id: "2") { _bramble_id: id name } _2: getOwner(id: "3") { _bramble_id: id name } }`}
 	ctx := testContextWithoutVariables(nil)
-	docs, err := buildBoundaryQueryDocuments(ctx, "name", schema, step, ids, boundaryField, 10)
+	docs, vars, err := buildBoundaryQueryDocuments(ctx, schema, step, ids, boundaryField, 10)
 	require.NoError(t, err)
 	require.Equal(t, expected, docs)
+	require.Equal(t, (map[string]interface{})(nil), vars)
+}
+
+func TestBuildNonArrayBoundaryQueryDocumentsWithVariables(t *testing.T) {
+	ddl := `
+		type Gizmo {
+			id: ID!
+			color: String!
+			owner: Owner
+		}
+
+		type Owner {
+			id: ID!
+			name(format: String): String!
+		}
+
+		type Query {
+			gizmos: [Gizmo!]!
+			getOwner(id: ID!): Owner!
+		}
+	`
+	schema := gqlparser.MustLoadSchema(&ast.Source{Name: "fixture", Input: ddl})
+	boundaryField := BoundaryField{Field: "getOwner", Argument: "id", Array: false}
+	ids := []string{"1", "2", "3"}
+	query := gqlparser.MustLoadQuery(schema, `query ($format: String) {
+		getOwner(id: "") { _bramble_id: id name(format: $format) }
+	}`)
+
+	step := &QueryPlanStep{
+		ServiceURL:     "http://example.com:8080",
+		ServiceName:    "test",
+		ParentType:     "Gizmo",
+		SelectionSet:   query.Operations[0].SelectionSet[0].(*ast.Field).SelectionSet,
+		InsertionPoint: []string{"gizmos", "owner"},
+		Then:           nil,
+	}
+
+	expected := []string{`query ($format: String) { _0: getOwner(id: "1") { _bramble_id: id name(format: $format) } _1: getOwner(id: "2") { _bramble_id: id name(format: $format) } _2: getOwner(id: "3") { _bramble_id: id name(format: $format) } }`}
+	ctx := testContextWithVariables(map[string]interface{}{"format": "lower"}, query.Operations[0])
+	docs, vars, err := buildBoundaryQueryDocuments(ctx, schema, step, ids, boundaryField, 10)
+	require.NoError(t, err)
+	require.Equal(t, expected, docs)
+	require.Equal(t, map[string]interface{}{"format": "lower"}, vars)
 }
 
 func TestBuildBatchedNonArrayBoundaryQueryDocuments(t *testing.T) {
@@ -154,9 +239,10 @@ func TestBuildBatchedNonArrayBoundaryQueryDocuments(t *testing.T) {
 	}
 	expected := []string{`query op { _0: getOwner(id: "1") { _bramble_id: id name } _1: getOwner(id: "2") { _bramble_id: id name } }`, `query op { _2: getOwner(id: "3") { _bramble_id: id name } }`}
 	ctx := testContextWithoutVariables(nil)
-	docs, err := buildBoundaryQueryDocuments(ctx, "op", schema, step, ids, boundaryField, 2)
+	docs, vars, err := buildBoundaryQueryDocuments(ctx, schema, step, ids, boundaryField, 2)
 	require.NoError(t, err)
 	require.Equal(t, expected, docs)
+	require.Equal(t, (map[string]interface{})(nil), vars)
 }
 
 func TestUnionAndTrimSelectionSet(t *testing.T) {

--- a/execution_test.go
+++ b/execution_test.go
@@ -3572,15 +3572,12 @@ func assertQueriesEqual(t *testing.T, schema, expected, actual string) bool {
 }
 
 func testContextWithoutVariables(op *ast.OperationDefinition) context.Context {
-	operationName := ""
-	if op != nil {
-		operationName = op.Name
-	} else {
+	if op == nil {
 		op = &ast.OperationDefinition{}
 	}
 
 	return AddPermissionsToContext(graphql.WithOperationContext(context.Background(), &graphql.OperationContext{
-		OperationName: operationName,
+		OperationName: op.Name,
 		Variables:     map[string]interface{}{},
 		Operation:     op,
 	}), OperationPermissions{
@@ -3591,15 +3588,12 @@ func testContextWithoutVariables(op *ast.OperationDefinition) context.Context {
 }
 
 func testContextWithNoPermissions(op *ast.OperationDefinition) context.Context {
-	operationName := ""
-	if op != nil {
-		operationName = op.Name
-	} else {
+	if op == nil {
 		op = &ast.OperationDefinition{}
 	}
 
 	return AddPermissionsToContext(graphql.WithOperationContext(context.Background(), &graphql.OperationContext{
-		OperationName: operationName,
+		OperationName: op.Name,
 		Variables:     map[string]interface{}{},
 		Operation:     op,
 	}), OperationPermissions{
@@ -3610,15 +3604,12 @@ func testContextWithNoPermissions(op *ast.OperationDefinition) context.Context {
 }
 
 func testContextWithVariables(vars map[string]interface{}, op *ast.OperationDefinition) context.Context {
-	operationName := ""
-	if op != nil {
-		operationName = op.Name
-	} else {
+	if op == nil {
 		op = &ast.OperationDefinition{}
 	}
 
 	return AddPermissionsToContext(graphql.WithResponseContext(graphql.WithOperationContext(context.Background(), &graphql.OperationContext{
-		OperationName: operationName,
+		OperationName: op.Name,
 		Variables:     vars,
 		Operation:     op,
 	}), graphql.DefaultErrorPresenter, graphql.DefaultRecover), OperationPermissions{

--- a/execution_test.go
+++ b/execution_test.go
@@ -3594,9 +3594,15 @@ func testContextWithNoPermissions(op *ast.OperationDefinition) context.Context {
 }
 
 func testContextWithVariables(vars map[string]interface{}, op *ast.OperationDefinition) context.Context {
+	operationName := ""
+	if op != nil {
+		operationName = op.Name
+	}
+
 	return AddPermissionsToContext(graphql.WithResponseContext(graphql.WithOperationContext(context.Background(), &graphql.OperationContext{
-		Variables: vars,
-		Operation: op,
+		OperationName: operationName,
+		Variables:     vars,
+		Operation:     op,
 	}), graphql.DefaultErrorPresenter, graphql.DefaultRecover), OperationPermissions{
 		AllowedRootQueryFields:        AllowedFields{AllowAll: true},
 		AllowedRootMutationFields:     AllowedFields{AllowAll: true},

--- a/execution_test.go
+++ b/execution_test.go
@@ -3572,9 +3572,17 @@ func assertQueriesEqual(t *testing.T, schema, expected, actual string) bool {
 }
 
 func testContextWithoutVariables(op *ast.OperationDefinition) context.Context {
+	operationName := ""
+	if op != nil {
+		operationName = op.Name
+	} else {
+		op = &ast.OperationDefinition{}
+	}
+
 	return AddPermissionsToContext(graphql.WithOperationContext(context.Background(), &graphql.OperationContext{
-		Variables: map[string]interface{}{},
-		Operation: op,
+		OperationName: operationName,
+		Variables:     map[string]interface{}{},
+		Operation:     op,
 	}), OperationPermissions{
 		AllowedRootQueryFields:        AllowedFields{AllowAll: true},
 		AllowedRootMutationFields:     AllowedFields{AllowAll: true},
@@ -3583,9 +3591,17 @@ func testContextWithoutVariables(op *ast.OperationDefinition) context.Context {
 }
 
 func testContextWithNoPermissions(op *ast.OperationDefinition) context.Context {
+	operationName := ""
+	if op != nil {
+		operationName = op.Name
+	} else {
+		op = &ast.OperationDefinition{}
+	}
+
 	return AddPermissionsToContext(graphql.WithOperationContext(context.Background(), &graphql.OperationContext{
-		Variables: map[string]interface{}{},
-		Operation: op,
+		OperationName: operationName,
+		Variables:     map[string]interface{}{},
+		Operation:     op,
 	}), OperationPermissions{
 		AllowedRootQueryFields:        AllowedFields{},
 		AllowedRootMutationFields:     AllowedFields{},
@@ -3597,6 +3613,8 @@ func testContextWithVariables(vars map[string]interface{}, op *ast.OperationDefi
 	operationName := ""
 	if op != nil {
 		operationName = op.Name
+	} else {
+		op = &ast.OperationDefinition{}
 	}
 
 	return AddPermissionsToContext(graphql.WithResponseContext(graphql.WithOperationContext(context.Background(), &graphql.OperationContext{

--- a/format.go
+++ b/format.go
@@ -3,9 +3,7 @@ package bramble
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
-	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
@@ -33,6 +31,73 @@ func indentPrefix(sb *strings.Builder, level int, suffix ...string) (int, error)
 		}
 	}
 	return total, nil
+}
+
+func formatDocument(ctx context.Context, schema *ast.Schema, operationType string, selectionSet ast.SelectionSet) string {
+	return strings.ToLower(operationType) + formatOperation(ctx, selectionSet) + formatSelectionSet(ctx, schema, selectionSet)
+}
+
+func formatOperation(ctx context.Context, selection ast.SelectionSet) string {
+	sb := strings.Builder{}
+
+	if !graphql.HasOperationContext(ctx) {
+		return ""
+	}
+	operationCtx := graphql.GetOperationContext(ctx)
+
+	var arguments []string
+	variableNames := variables(selection)
+	for _, variableDefinition := range operationCtx.Operation.VariableDefinitions {
+		if _, exists := variableNames[variableDefinition.Variable]; !exists {
+			continue
+		}
+
+		argument := fmt.Sprintf("$%s: %s", variableDefinition.Variable, variableDefinition.Type.String())
+		arguments = append(arguments, argument)
+	}
+
+	sb.WriteString(" " + operationCtx.OperationName)
+	if len(arguments) == 0 {
+		return sb.String()
+	}
+
+	sb.WriteString("(")
+	sb.WriteString(strings.Join(arguments, ","))
+	sb.WriteString(")")
+
+	return sb.String()
+}
+
+func variables(selectionSet ast.SelectionSet) map[string]interface{} {
+	var names []string
+	for _, s := range selectionSet {
+		switch selection := s.(type) {
+		case *ast.Field:
+			for _, a := range selection.Arguments {
+				names = append(names, variableNames(a.Value, names)...)
+			}
+		}
+	}
+
+	uniqueNames := map[string]interface{}{}
+	for _, n := range names {
+		uniqueNames[n] = struct{}{}
+	}
+
+	return uniqueNames
+}
+
+func variableNames(a *ast.Value, names []string) []string {
+	switch a.Kind {
+	case ast.Variable:
+		names = append(names, a.Raw)
+	default:
+		for _, child := range a.Children {
+			names = append(names, variableNames(child.Value, names)...)
+		}
+	}
+
+	return names
 }
 
 func formatSelectionSelectionSet(sb *strings.Builder, schema *ast.Schema, vars map[string]interface{}, level int, selectionSet ast.SelectionSet) {
@@ -95,7 +160,7 @@ func formatSelectionSet(ctx context.Context, schema *ast.Schema, selection ast.S
 
 	sb.WriteString("{")
 	formatSelection(&sb, schema, vars, 0, selection)
-	sb.WriteString("\n}")
+	sb.WriteString(" }")
 
 	return sb.String()
 }
@@ -120,7 +185,7 @@ func formatArgument(schema *ast.Schema, v *ast.Value, vars map[string]interface{
 	}
 	switch v.Kind {
 	case ast.Variable:
-		return expandAndFormatVariable(schema, schema.Types[v.ExpectedType.Name()], vars[v.Raw])
+		return "$" + v.Raw
 	case ast.IntValue, ast.FloatValue, ast.EnumValue, ast.BooleanValue, ast.NullValue:
 		return v.Raw
 	case ast.StringValue, ast.BlockValue:
@@ -140,69 +205,6 @@ func formatArgument(schema *ast.Schema, v *ast.Value, vars map[string]interface{
 	default:
 		panic(fmt.Errorf("unknown value kind %d", v.Kind))
 	}
-}
-
-func expandAndFormatVariable(schema *ast.Schema, objectType *ast.Definition, v interface{}) string {
-	if v == nil {
-		return "null"
-	}
-
-	switch objectType.Kind {
-	case ast.Scalar:
-		b, _ := json.Marshal(v)
-		return string(b)
-	case ast.Enum:
-		return fmt.Sprint(v)
-	case ast.Object, ast.InputObject, ast.Interface, ast.Union:
-		switch v := v.(type) {
-		case map[string]interface{}:
-			var buf strings.Builder
-			buf.WriteString("{")
-
-			for i, f := range objectType.Fields {
-				if i != 0 {
-					buf.WriteString(" ")
-				}
-
-				fieldName := f.Name
-				value, ok := v[fieldName]
-				if !ok {
-					continue
-				}
-
-				// if it's a list we call recursively on every element
-				if f.Type.Elem != nil {
-					switch reflect.TypeOf(value).Kind() {
-					case reflect.Slice:
-						s := reflect.ValueOf(value)
-						var elems []string
-						for i := 0; i < s.Len(); i++ {
-							elems = append(elems, expandAndFormatVariable(schema, schema.Types[f.Type.Elem.Name()], s.Index(i).Interface()))
-						}
-						fmt.Fprintf(&buf, "%s: [%s]", fieldName, strings.Join(elems, ", "))
-						continue
-					default:
-						panic("invalid type, expected slice")
-					}
-				}
-
-				fmt.Fprintf(&buf, "%s: %s", fieldName, expandAndFormatVariable(schema, schema.Types[f.Type.Name()], value))
-			}
-
-			buf.WriteString("}")
-			return buf.String()
-		case []interface{}:
-			var val []string
-			for _, elem := range v {
-				val = append(val, expandAndFormatVariable(schema, objectType, elem))
-			}
-			return "[" + strings.Join(val, ",") + "]"
-		default:
-			panic("unknown type " + reflect.TypeOf(v).String())
-		}
-	}
-
-	return ""
 }
 
 func formatSchema(schema *ast.Schema) string {

--- a/format_test.go
+++ b/format_test.go
@@ -122,8 +122,8 @@ func TestFormatSelectionSetWithObjectVariable(t *testing.T) {
 		"subObject": map[string]interface{}{
 			"genre": "ACTION",
 		},
-	}}, nil), schema, query.Operations[0].SelectionSet)
-	assert.Equal(t, `{ search(input: {genre: ACTION genreList: [ACTION, COMEDY] stringList: ["abc", "123"] intList: [123] subObject: {genre: ACTION}}) { genre } }`, res)
+	}}, query.Operations[0]), schema, query.Operations[0].SelectionSet)
+	assert.Equal(t, `{ search(input: $input) { genre } }`, res)
 }
 
 func TestFormatSelectionSetWithListOfObjectVariable(t *testing.T) {
@@ -145,7 +145,7 @@ func TestFormatSelectionSetWithListOfObjectVariable(t *testing.T) {
 	res := formatSelectionSetSingleLine(testContextWithVariables(map[string]interface{}{"input": []interface{}{
 		map[string]interface{}{"name": "name", "value": "value"},
 	}}, nil), schema, query.Operations[0].SelectionSet)
-	assert.Equal(t, `{ search(input: [{name: "name" value: "value"}]) }`, res)
+	assert.Equal(t, `{ search(input: $input) }`, res)
 }
 
 func TestFormatSelectionSetWithListContainingVariable(t *testing.T) {
@@ -164,7 +164,7 @@ func TestFormatSelectionSetWithListContainingVariable(t *testing.T) {
 	}`)
 
 	res := formatSelectionSetSingleLine(testContextWithVariables(map[string]interface{}{"id": 1234}, nil), schema, query.Operations[0].SelectionSet)
-	assert.Equal(t, `{ moviesByIds(ids: [1234]) { id } }`, res)
+	assert.Equal(t, `{ moviesByIds(ids: [$id]) { id } }`, res)
 }
 
 func TestFormatSelectionSetWithEnum(t *testing.T) {
@@ -218,7 +218,7 @@ func TestFormatSelectionSetWithEnumVariable(t *testing.T) {
 	}`)
 
 	res := formatSelectionSetSingleLine(testContextWithVariables(map[string]interface{}{"genre": "ACTION"}, nil), schema, query.Operations[0].SelectionSet)
-	assert.Equal(t, `{ search(input: {genre:ACTION}) { genre } }`, res)
+	assert.Equal(t, `{ search(input: {genre:$genre}) { genre } }`, res)
 }
 
 func TestFormatSelectionSetWithNullEnumVariable(t *testing.T) {
@@ -245,7 +245,7 @@ func TestFormatSelectionSetWithNullEnumVariable(t *testing.T) {
 	}`)
 
 	res := formatSelectionSetSingleLine(testContextWithVariables(map[string]interface{}{"genre": nil}, nil), schema, query.Operations[0].SelectionSet)
-	assert.Equal(t, `{ search(input: {genre:null}) { genre } }`, res)
+	assert.Equal(t, `{ search(input: {genre:$genre}) { genre } }`, res)
 }
 
 func TestFormatSelectionSetInlineFragment(t *testing.T) {
@@ -369,6 +369,230 @@ func TestFormatEnum(t *testing.T) {
 		"e": "English",
 	}
 
-	assert.Equal(t, "French", formatArgument(schema, &ast.Value{Kind: ast.Variable, Raw: "f", ExpectedType: typ}, vars))
-	assert.Equal(t, "English", formatArgument(schema, &ast.Value{Kind: ast.Variable, Raw: "e", ExpectedType: typ}, vars))
+	assert.Equal(t, "$f", formatArgument(schema, &ast.Value{Kind: ast.Variable, Raw: "f", ExpectedType: typ}, vars))
+	assert.Equal(t, "$e", formatArgument(schema, &ast.Value{Kind: ast.Variable, Raw: "e", ExpectedType: typ}, vars))
+}
+
+func TestFormatDocument(t *testing.T) {
+	schema := loadSchema(`
+	type Movie {
+		id: ID!
+		title: String!
+	}
+
+	type Query {
+		search(id: ID!): Movie
+	}
+	`)
+
+	query := gqlparser.MustLoadQuery(schema, `query {
+		search(id: "123") { id title }
+	}`)
+
+	operationDefinition := query.Operations[0]
+	res := formatDocument(
+		testContextWithVariables(map[string]interface{}{"id": "123"}, operationDefinition),
+		schema,
+		string(operationDefinition.Operation),
+		operationDefinition.SelectionSet,
+	)
+	assert.Equal(t, `query {    search(id: "123") {        id        title    } }`, res)
+}
+
+func TestFormatDocumentWithOperationName(t *testing.T) {
+	schema := loadSchema(`
+	type Movie {
+		id: ID!
+		title: String!
+	}
+
+	type Query {
+		search(id: ID!): Movie
+	}
+	`)
+
+	query := gqlparser.MustLoadQuery(schema, `query search {
+		search(id: "123") { id title }
+	}`)
+
+	operationDefinition := query.Operations[0]
+	res := formatDocument(
+		testContextWithVariables(map[string]interface{}{"id": "123"}, operationDefinition),
+		schema,
+		string(operationDefinition.Operation),
+		operationDefinition.SelectionSet,
+	)
+	assert.Equal(t, `query search{    search(id: "123") {        id        title    } }`, res)
+}
+
+func TestFormatDocumentWithVariable(t *testing.T) {
+	schema := loadSchema(`
+	type Movie {
+		id: ID!
+		title: String!
+	}
+
+	type Query {
+		search(id: ID!): Movie
+	}
+	`)
+
+	query := gqlparser.MustLoadQuery(schema, `query search($id: ID!) {
+		search(id: $id) { id title }
+	}`)
+
+	operationDefinition := query.Operations[0]
+	res := formatDocument(
+		testContextWithVariables(nil, operationDefinition),
+		schema,
+		string(operationDefinition.Operation),
+		operationDefinition.SelectionSet,
+	)
+	assert.Equal(t, `query search($id: ID!){    search(id: $id) {        id        title    } }`, res)
+}
+
+func TestFormatDocumentWithListVariable(t *testing.T) {
+	schema := loadSchema(`
+	type Movie {
+		id: ID!
+		title: String!
+	}
+
+	type Query {
+		search(ids: [ID!]): Movie
+	}
+	`)
+
+	query := gqlparser.MustLoadQuery(schema, `query search($ids: [ID!]) {
+		search(ids: $ids) { id title }
+	}`)
+
+	operationDefinition := query.Operations[0]
+	res := formatDocument(
+		testContextWithVariables(nil, operationDefinition),
+		schema,
+		string(operationDefinition.Operation),
+		operationDefinition.SelectionSet,
+	)
+	assert.Equal(t, `query search($ids: [ID!]){    search(ids: $ids) {        id        title    } }`, res)
+}
+
+func TestFormatDocumentWithVariableWithinList(t *testing.T) {
+	schema := loadSchema(`
+	type Movie {
+		id: ID!
+		title: String!
+	}
+
+	type Query {
+		search(ids: [ID!]): Movie
+	}
+	`)
+
+	query := gqlparser.MustLoadQuery(schema, `query search($id: ID!) {
+		search(ids: ["123", $id, "789"]) { id title }
+	}`)
+
+	operationDefinition := query.Operations[0]
+	res := formatDocument(
+		testContextWithVariables(nil, operationDefinition),
+		schema,
+		string(operationDefinition.Operation),
+		operationDefinition.SelectionSet,
+	)
+	assert.Equal(t, `query search($id: ID!){    search(ids: ["123",$id,"789"]) {        id        title    } }`, res)
+}
+
+func TestFormatDocumentWithInputVariable(t *testing.T) {
+	schema := loadSchema(`
+	type Movie {
+		id: ID!
+		title: String!
+	}
+
+	input Filter {
+		id: ID!
+	}
+
+	type Query {
+		search(filter: Filter): Movie
+	}
+	`)
+
+	query := gqlparser.MustLoadQuery(schema, `query search($filter: Filter) {
+		search(filter: $filter) { id title }
+	}`)
+
+	operationDefinition := query.Operations[0]
+	res := formatDocument(
+		testContextWithVariables(nil, operationDefinition),
+		schema,
+		string(operationDefinition.Operation),
+		operationDefinition.SelectionSet,
+	)
+	assert.Equal(t, `query search($filter: Filter){    search(filter: $filter) {        id        title    } }`, res)
+}
+
+func TestFormatDocumentWithVariableWithinInput(t *testing.T) {
+	schema := loadSchema(`
+	type Movie {
+		id: ID!
+		title: String!
+	}
+
+	input Filter {
+		id: ID!
+	}
+
+	type Query {
+		search(filter: Filter): Movie
+	}
+	`)
+
+	query := gqlparser.MustLoadQuery(schema, `query search($id: ID!) {
+		search(filter: {id: $id}) { id title }
+	}`)
+
+	operationDefinition := query.Operations[0]
+	res := formatDocument(
+		testContextWithVariables(nil, operationDefinition),
+		schema,
+		string(operationDefinition.Operation),
+		operationDefinition.SelectionSet,
+	)
+	assert.Equal(t, `query search($id: ID!){    search(filter: {id:$id}) {        id        title    } }`, res)
+}
+
+func TestFormatDocumentWithVariableWithinNestedInput(t *testing.T) {
+	schema := loadSchema(`
+	type Movie {
+		id: ID!
+		title: String!
+	}
+
+	input SubFilter {
+		id: ID!
+	}
+
+	input Filter {
+		sub: SubFilter
+	}
+
+	type Query {
+		search(filter: Filter): Movie
+	}
+	`)
+
+	query := gqlparser.MustLoadQuery(schema, `query search($id: ID!) {
+		search(filter: {sub: {id: $id}}) { id title }
+	}`)
+
+	operationDefinition := query.Operations[0]
+	res := formatDocument(
+		testContextWithVariables(map[string]interface{}{"filter": `{id: "123"}`}, operationDefinition),
+		schema,
+		string(operationDefinition.Operation),
+		operationDefinition.SelectionSet,
+	)
+	assert.Equal(t, `query search($id: ID!){    search(filter: {sub:{id:$id}}) {        id        title    } }`, res)
 }

--- a/format_test.go
+++ b/format_test.go
@@ -390,13 +390,14 @@ func TestFormatDocument(t *testing.T) {
 	}`)
 
 	operationDefinition := query.Operations[0]
-	res := formatDocument(
+	res, vars := formatDocument(
 		testContextWithVariables(map[string]interface{}{"id": "123"}, operationDefinition),
 		schema,
 		string(operationDefinition.Operation),
 		operationDefinition.SelectionSet,
 	)
 	assert.Equal(t, `query {    search(id: "123") {        id        title    } }`, res)
+	assert.Equal(t, (map[string]interface{})(nil), vars)
 }
 
 func TestFormatDocumentWithOperationName(t *testing.T) {
@@ -416,13 +417,14 @@ func TestFormatDocumentWithOperationName(t *testing.T) {
 	}`)
 
 	operationDefinition := query.Operations[0]
-	res := formatDocument(
+	res, vars := formatDocument(
 		testContextWithVariables(map[string]interface{}{"id": "123"}, operationDefinition),
 		schema,
 		string(operationDefinition.Operation),
 		operationDefinition.SelectionSet,
 	)
 	assert.Equal(t, `query search{    search(id: "123") {        id        title    } }`, res)
+	assert.Equal(t, (map[string]interface{})(nil), vars)
 }
 
 func TestFormatDocumentWithVariable(t *testing.T) {
@@ -442,13 +444,14 @@ func TestFormatDocumentWithVariable(t *testing.T) {
 	}`)
 
 	operationDefinition := query.Operations[0]
-	res := formatDocument(
-		testContextWithVariables(nil, operationDefinition),
+	res, vars := formatDocument(
+		testContextWithVariables(map[string]interface{}{"id": "123", "extra": "ignore"}, operationDefinition),
 		schema,
 		string(operationDefinition.Operation),
 		operationDefinition.SelectionSet,
 	)
 	assert.Equal(t, `query search($id: ID!){    search(id: $id) {        id        title    } }`, res)
+	assert.Equal(t, map[string]interface{}{"id": "123"}, vars)
 }
 
 func TestFormatDocumentWithListVariable(t *testing.T) {
@@ -468,13 +471,14 @@ func TestFormatDocumentWithListVariable(t *testing.T) {
 	}`)
 
 	operationDefinition := query.Operations[0]
-	res := formatDocument(
-		testContextWithVariables(nil, operationDefinition),
+	res, vars := formatDocument(
+		testContextWithVariables(map[string]interface{}{"ids": `["123", "456"]`, "extra": "ignore"}, operationDefinition),
 		schema,
 		string(operationDefinition.Operation),
 		operationDefinition.SelectionSet,
 	)
 	assert.Equal(t, `query search($ids: [ID!]){    search(ids: $ids) {        id        title    } }`, res)
+	assert.Equal(t, map[string]interface{}{"ids": `["123", "456"]`}, vars)
 }
 
 func TestFormatDocumentWithVariableWithinList(t *testing.T) {
@@ -494,13 +498,14 @@ func TestFormatDocumentWithVariableWithinList(t *testing.T) {
 	}`)
 
 	operationDefinition := query.Operations[0]
-	res := formatDocument(
-		testContextWithVariables(nil, operationDefinition),
+	res, vars := formatDocument(
+		testContextWithVariables(map[string]interface{}{"id": "123", "extra": "ignore"}, operationDefinition),
 		schema,
 		string(operationDefinition.Operation),
 		operationDefinition.SelectionSet,
 	)
 	assert.Equal(t, `query search($id: ID!){    search(ids: ["123",$id,"789"]) {        id        title    } }`, res)
+	assert.Equal(t, map[string]interface{}{"id": "123"}, vars)
 }
 
 func TestFormatDocumentWithInputVariable(t *testing.T) {
@@ -524,13 +529,14 @@ func TestFormatDocumentWithInputVariable(t *testing.T) {
 	}`)
 
 	operationDefinition := query.Operations[0]
-	res := formatDocument(
-		testContextWithVariables(nil, operationDefinition),
+	res, vars := formatDocument(
+		testContextWithVariables(map[string]interface{}{"filter": `{id: "123"}`, "extra": "ignore"}, operationDefinition),
 		schema,
 		string(operationDefinition.Operation),
 		operationDefinition.SelectionSet,
 	)
 	assert.Equal(t, `query search($filter: Filter){    search(filter: $filter) {        id        title    } }`, res)
+	assert.Equal(t, map[string]interface{}{"filter": `{id: "123"}`}, vars)
 }
 
 func TestFormatDocumentWithVariableWithinInput(t *testing.T) {
@@ -554,13 +560,14 @@ func TestFormatDocumentWithVariableWithinInput(t *testing.T) {
 	}`)
 
 	operationDefinition := query.Operations[0]
-	res := formatDocument(
-		testContextWithVariables(nil, operationDefinition),
+	res, vars := formatDocument(
+		testContextWithVariables(map[string]interface{}{"id": "123", "extra": "ignore"}, operationDefinition),
 		schema,
 		string(operationDefinition.Operation),
 		operationDefinition.SelectionSet,
 	)
 	assert.Equal(t, `query search($id: ID!){    search(filter: {id:$id}) {        id        title    } }`, res)
+	assert.Equal(t, map[string]interface{}{"id": "123"}, vars)
 }
 
 func TestFormatDocumentWithVariableWithinNestedInput(t *testing.T) {
@@ -588,11 +595,12 @@ func TestFormatDocumentWithVariableWithinNestedInput(t *testing.T) {
 	}`)
 
 	operationDefinition := query.Operations[0]
-	res := formatDocument(
-		testContextWithVariables(map[string]interface{}{"filter": `{id: "123"}`}, operationDefinition),
+	res, vars := formatDocument(
+		testContextWithVariables(map[string]interface{}{"id": "123", "extra": "ignore"}, operationDefinition),
 		schema,
 		string(operationDefinition.Operation),
 		operationDefinition.SelectionSet,
 	)
 	assert.Equal(t, `query search($id: ID!){    search(filter: {sub:{id:$id}}) {        id        title    } }`, res)
+	assert.Equal(t, map[string]interface{}{"id": "123"}, vars)
 }


### PR DESCRIPTION
Instead of inlining variables into downstream queries, which failed when the serialisation of the value from json didn't match the graphql syntax (eg if the variable was a complex json type) filter the variables map to the values required by the downstream query.

This should enable the definition of things like a json scalar value without bramble interfering and generating a syntactically invalid query.