### PR TITLE
Add example for Bramble as HTTP handler

### DIFF
--- a/examples/as-http-handler/main.go
+++ b/examples/as-http-handler/main.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/movio/bramble"
+)
+
+const defaultPort = "8080"
+
+func main() {
+	port := os.Getenv("BRAMBLE_PORT")
+	if port == "" {
+		port = defaultPort
+	}
+
+	configFile := os.Getenv("BRAMBLE_CONFIG")
+	if configFile == "" {
+		configFile = "config.json"
+	}
+
+	cfg, err := bramble.GetConfig([]string{configFile})
+	if err != nil {
+		log.Fatalf(fmt.Errorf("failed to load config files: %w", err).Error())
+	}
+	go cfg.Watch()
+
+	err = cfg.Init()
+	if err != nil {
+		log.Fatalf(fmt.Errorf("failed to load initialize config: %w", err).Error())
+	}
+
+	gateway := bramble.FromConfig(cfg)
+
+	mux := http.NewServeMux()
+	mux.Handle("/", gateway.Router())
+
+	log.Fatal(http.ListenAndServe(":"+port, mux))
+}

--- a/gateway.go
+++ b/gateway.go
@@ -25,6 +25,10 @@ func NewGateway(executableSchema *ExecutableSchema, plugins []Plugin) *Gateway {
 	}
 }
 
+func FromConfig(cfg *Config) *Gateway {
+	return NewGateway(cfg.executableSchema, cfg.plugins)
+}
+
 // UpdateSchemas periodically updates the execute schema
 func (g *Gateway) UpdateSchemas(interval time.Duration) {
 	for range time.Tick(interval) {


### PR DESCRIPTION
This adds an example on how to use Bramble as an HTTP handler. 