### PR TITLE
Update docker-compose setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,8 @@
 .git
-docs
-contrib
 Dockerfile
 Makefile
+bramble
+contrib
+docs
+examples
+testsrv

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
-FROM golang:1.17 AS builder
+FROM golang:1.17-alpine3.15 AS builder
 
 ARG VERSION=SNAPSHOT
 ENV GO111MODULE=on
+ENV CGO_ENABLED=0
 
 WORKDIR /workspace
 
@@ -9,9 +10,7 @@ COPY go.mod go.sum /workspace/
 
 RUN go mod download
 
-COPY *.go /workspace/
-COPY cmd /workspace/cmd
-COPY plugins /workspace/plugins
+COPY . /workspace/
 
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-X 'github.com/movio/bramble.Version=$VERSION'" -o bramble ./cmd/bramble
 
@@ -23,4 +22,4 @@ EXPOSE 8082
 EXPOSE 8083
 EXPOSE 8084
 
-CMD [ "/bramble", "-conf", "/config.json" ]
+CMD [ "/bramble", "-config", "/config.json" ]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
     build:
       context: examples/gqlgen-service
     healthcheck:
-      test: curl --fail http://localhost:8080/health || exit 1
+      test: wget -qO - http://localhost:8080/health
       interval: 5s
       timeout: 1s
       retries: 5
@@ -12,7 +12,7 @@ services:
       - 8080
   gophers-server:
     healthcheck:
-      test: curl --fail http://localhost:8080/health || exit 1
+      test: wget -qO - http://localhost:8080/health
       interval: 5s
       timeout: 1s
       retries: 5
@@ -22,7 +22,7 @@ services:
       - 8080
   nodejs-server:
     healthcheck:
-      test: curl --fail http://localhost:8080/health || exit 1
+      test: wget -qO - http://localhost:8080/health
       interval: 5s
       timeout: 1s
       retries: 5

--- a/examples/gqlgen-service/Dockerfile
+++ b/examples/gqlgen-service/Dockerfile
@@ -1,4 +1,6 @@
-FROM golang
+FROM golang:1.17-alpine3.15
+
+ENV CGO_ENABLED=0
 
 WORKDIR /go/src/app
 

--- a/examples/graph-gophers-service/Dockerfile
+++ b/examples/graph-gophers-service/Dockerfile
@@ -1,4 +1,6 @@
-FROM golang
+FROM golang:1.17-alpine3.15
+
+ENV CGO_ENABLED=0
 
 WORKDIR /go/src/app
 

--- a/examples/nodejs-service/Dockerfile
+++ b/examples/nodejs-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM node
+FROM node:18-alpine3.15
 
 COPY . .
 


### PR DESCRIPTION
- Simplify the copying of go files into docker context when building the gateway
- Pin the example services to golang:1.17 and node:18