### PR TITLE
Propogate `operationName` to subqueries

### DIFF
--- a/client.go
+++ b/client.go
@@ -170,6 +170,11 @@ func (r *Request) WithHeaders(headers http.Header) *Request {
 	return r
 }
 
+func (r *Request) WithOperationName(operationName string) *Request {
+	r.OperationName = operationName
+	return r
+}
+
 // Response is a GraphQL response
 type Response struct {
 	Errors GraphqlErrors `json:"errors"`

--- a/executable_schema.go
+++ b/executable_schema.go
@@ -195,7 +195,7 @@ func (s *ExecutableSchema) ExecuteQuery(ctx context.Context) *graphql.Response {
 
 	executionStart := time.Now()
 
-	qe := newQueryExecution(ctx, s.GraphqlClient, filteredSchema, s.BoundaryQueries, int32(s.MaxRequestsPerQuery))
+	qe := newQueryExecution(ctx, operationCtx.OperationName, s.GraphqlClient, filteredSchema, s.BoundaryQueries, int32(s.MaxRequestsPerQuery))
 	results, executeErrs := qe.Execute(plan)
 	if len(executeErrs) > 0 {
 		return &graphql.Response{

--- a/execution.go
+++ b/execution.go
@@ -291,14 +291,16 @@ func (q *queryExecution) createGQLErrors(step *QueryPlanStep, err error) gqlerro
 // have insertionPoint: ["foo", "bar", "movies", "movie", "compTitles"], with the below example as the boundary result we're
 // crawling for ids:
 // [
-// 	 {
-//     "_bramble_id": "MOVIE1",
-//     "compTitles": [
-//       {
-//   	   "_bramble_id": "1"
-// 		 }
-//	   ]
-//   }
+//
+//		 {
+//	    "_bramble_id": "MOVIE1",
+//	    "compTitles": [
+//	      {
+//	  	   "_bramble_id": "1"
+//			 }
+//		   ]
+//	  }
+//
 // ]
 //
 // We therefore cannot use the insertionPoint as is in order to extract the boundary ids for the next child step.
@@ -467,9 +469,9 @@ func batchBy(items []string, batchSize int) (batches [][]string) {
 
 // When formatting the response data, the shape of the selection set has to potentially be modified to more closely resemble the shape
 // of the response. This only happens when running into fragments, there are two cases we need to deal with:
-//   1. the selection set of the target fragment has to be unioned with the selection set at the level for which the target fragment is referenced
-//   2. if the target fragments are an implementation of an abstract type, we need to use the __typename from the response body to check which
-//   implementation was resolved. Any fragments that do not match are dropped from the selection set.
+//  1. the selection set of the target fragment has to be unioned with the selection set at the level for which the target fragment is referenced
+//  2. if the target fragments are an implementation of an abstract type, we need to use the __typename from the response body to check which
+//     implementation was resolved. Any fragments that do not match are dropped from the selection set.
 func unionAndTrimSelectionSet(responseObjectTypeName string, schema *ast.Schema, selectionSet ast.SelectionSet) ast.SelectionSet {
 	filteredSelectionSet := eliminateUnwantedFragments(responseObjectTypeName, schema, selectionSet)
 	return mergeWithTopLevelFragmentFields(filteredSelectionSet)

--- a/execution.go
+++ b/execution.go
@@ -24,6 +24,7 @@ type executionResult struct {
 
 type queryExecution struct {
 	ctx            context.Context
+	operationName  string
 	schema         *ast.Schema
 	requestCount   int32
 	maxRequest     int32
@@ -34,10 +35,11 @@ type queryExecution struct {
 	results chan executionResult
 }
 
-func newQueryExecution(ctx context.Context, client *GraphQLClient, schema *ast.Schema, boundaryFields BoundaryFieldsMap, maxRequest int32) *queryExecution {
+func newQueryExecution(ctx context.Context, operationName string, client *GraphQLClient, schema *ast.Schema, boundaryFields BoundaryFieldsMap, maxRequest int32) *queryExecution {
 	group, ctx := errgroup.WithContext(ctx)
 	return &queryExecution{
 		ctx:            ctx,
+		operationName:  operationName,
 		schema:         schema,
 		graphqlClient:  client,
 		boundaryFields: boundaryFields,
@@ -92,7 +94,8 @@ func (q *queryExecution) executeRootStep(step *QueryPlanStep) error {
 
 	switch operationType := step.ParentType; operationType {
 	case queryObjectName, mutationObjectName:
-		document = strings.ToLower(operationType) + formatSelectionSet(q.ctx, q.schema, step.SelectionSet)
+		selectionSet := formatSelectionSet(q.ctx, q.schema, step.SelectionSet)
+		document = fmt.Sprintf(`%s %s %s`, strings.ToLower(operationType), q.operationName, selectionSet)
 	default:
 		return errors.New("expected mutation or query root step")
 	}
@@ -126,7 +129,8 @@ func (q *queryExecution) executeRootStep(step *QueryPlanStep) error {
 
 func (q *queryExecution) executeDocument(document string, serviceURL string, response interface{}) error {
 	req := NewRequest(document).
-		WithHeaders(GetOutgoingRequestHeadersFromContext(q.ctx))
+		WithHeaders(GetOutgoingRequestHeadersFromContext(q.ctx)).
+		WithOperationName(q.operationName)
 	return q.graphqlClient.Request(q.ctx, serviceURL, req, &response)
 }
 
@@ -154,7 +158,7 @@ func (q *queryExecution) executeChildStep(step *QueryPlanStep, boundaryIDs []str
 		return err
 	}
 
-	documents, err := buildBoundaryQueryDocuments(q.ctx, q.schema, step, boundaryIDs, boundaryField, 50)
+	documents, err := buildBoundaryQueryDocuments(q.ctx, q.operationName, q.schema, step, boundaryIDs, boundaryField, 50)
 	if err != nil {
 		return err
 	}
@@ -430,7 +434,7 @@ func extractBoundaryIDs(data interface{}, insertionPoint []string, parentType st
 	}
 }
 
-func buildBoundaryQueryDocuments(ctx context.Context, schema *ast.Schema, step *QueryPlanStep, ids []string, parentTypeBoundaryField BoundaryField, batchSize int) ([]string, error) {
+func buildBoundaryQueryDocuments(ctx context.Context, operationName string, schema *ast.Schema, step *QueryPlanStep, ids []string, parentTypeBoundaryField BoundaryField, batchSize int) ([]string, error) {
 	selectionSetQL := formatSelectionSetSingleLine(ctx, schema, step.SelectionSet)
 	if parentTypeBoundaryField.Array {
 		qids := []string{}
@@ -438,7 +442,7 @@ func buildBoundaryQueryDocuments(ctx context.Context, schema *ast.Schema, step *
 			qids = append(qids, fmt.Sprintf("%q", id))
 		}
 		idsQL := fmt.Sprintf("[%s]", strings.Join(qids, ", "))
-		return []string{fmt.Sprintf(`{ _result: %s(%s: %s) %s }`, parentTypeBoundaryField.Field, parentTypeBoundaryField.Argument, idsQL, selectionSetQL)}, nil
+		return []string{fmt.Sprintf(`query %s { _result: %s(%s: %s) %s }`, operationName, parentTypeBoundaryField.Field, parentTypeBoundaryField.Argument, idsQL, selectionSetQL)}, nil
 	}
 
 	var (
@@ -452,7 +456,8 @@ func buildBoundaryQueryDocuments(ctx context.Context, schema *ast.Schema, step *
 			selections = append(selections, selection)
 			selectionIndex++
 		}
-		document := "{ " + strings.Join(selections, " ") + " }"
+
+		document := fmt.Sprintf("query %s { %s }", operationName, strings.Join(selections, " "))
 		documents = append(documents, document)
 	}
 

--- a/execution_helpers_test.go
+++ b/execution_helpers_test.go
@@ -52,9 +52,9 @@ func TestBuildBoundaryQueryDocuments(t *testing.T) {
 		InsertionPoint: []string{"gizmos", "owner"},
 		Then:           nil,
 	}
-	expected := []string{`{ _result: getOwners(ids: ["1", "2", "3"]) { _bramble_id: id name } }`}
+	expected := []string{`query operationName { _result: getOwners(ids: ["1", "2", "3"]) { _bramble_id: id name } }`}
 	ctx := testContextWithoutVariables(nil)
-	docs, err := buildBoundaryQueryDocuments(ctx, schema, step, ids, boundaryField, 1)
+	docs, err := buildBoundaryQueryDocuments(ctx, "operationName", schema, step, ids, boundaryField, 1)
 	require.NoError(t, err)
 	require.Equal(t, expected, docs)
 }
@@ -102,9 +102,9 @@ func TestBuildNonArrayBoundaryQueryDocuments(t *testing.T) {
 		InsertionPoint: []string{"gizmos", "owner"},
 		Then:           nil,
 	}
-	expected := []string{`{ _0: getOwner(id: "1") { _bramble_id: id name } _1: getOwner(id: "2") { _bramble_id: id name } _2: getOwner(id: "3") { _bramble_id: id name } }`}
+	expected := []string{`query name { _0: getOwner(id: "1") { _bramble_id: id name } _1: getOwner(id: "2") { _bramble_id: id name } _2: getOwner(id: "3") { _bramble_id: id name } }`}
 	ctx := testContextWithoutVariables(nil)
-	docs, err := buildBoundaryQueryDocuments(ctx, schema, step, ids, boundaryField, 10)
+	docs, err := buildBoundaryQueryDocuments(ctx, "name", schema, step, ids, boundaryField, 10)
 	require.NoError(t, err)
 	require.Equal(t, expected, docs)
 }
@@ -152,9 +152,9 @@ func TestBuildBatchedNonArrayBoundaryQueryDocuments(t *testing.T) {
 		InsertionPoint: []string{"gizmos", "owner"},
 		Then:           nil,
 	}
-	expected := []string{`{ _0: getOwner(id: "1") { _bramble_id: id name } _1: getOwner(id: "2") { _bramble_id: id name } }`, `{ _2: getOwner(id: "3") { _bramble_id: id name } }`}
+	expected := []string{`query op { _0: getOwner(id: "1") { _bramble_id: id name } _1: getOwner(id: "2") { _bramble_id: id name } }`, `query op { _2: getOwner(id: "3") { _bramble_id: id name } }`}
 	ctx := testContextWithoutVariables(nil)
-	docs, err := buildBoundaryQueryDocuments(ctx, schema, step, ids, boundaryField, 2)
+	docs, err := buildBoundaryQueryDocuments(ctx, "op", schema, step, ids, boundaryField, 2)
 	require.NoError(t, err)
 	require.Equal(t, expected, docs)
 }

--- a/introspection.go
+++ b/introspection.go
@@ -31,8 +31,8 @@ func NewService(serviceURL string) *Service {
 
 // Update queries the service's schema, name and version and updates its status.
 func (s *Service) Update() (bool, error) {
-	req := NewRequest("query brambleServicePoll { service { name, version, schema} }")
-	req.OperationName = "brambleServicePoll"
+	req := NewRequest("query brambleServicePoll { service { name, version, schema} }").
+		WithOperationName("brambleServicePoll")
 	response := struct {
 		Service struct {
 			Name    string `json:"name"`


### PR DESCRIPTION
This is useful for tracing and metrics. Currently child queries are made with an empty `operationName`. 