### PR TITLE
Pass through original graphql error path

### DIFF
--- a/execution.go
+++ b/execution.go
@@ -265,12 +265,13 @@ func (q *queryExecution) createGQLErrors(step *QueryPlanStep, err error) gqlerro
 				extensions = make(map[string]interface{})
 			}
 			extensions["selectionSet"] = formatSelectionSetSingleLine(q.ctx, q.schema, step.SelectionSet)
+			extensions["selectionPath"] = path
 			extensions["serviceName"] = step.ServiceName
 			extensions["serviceUrl"] = step.ServiceURL
 
 			outputErrs = append(outputErrs, &gqlerror.Error{
 				Message:    ge.Message,
-				Path:       path,
+				Path:       ge.Path,
 				Locations:  locs,
 				Extensions: extensions,
 			})
@@ -509,7 +510,6 @@ func eliminateUnwantedFragments(responseObjectTypeName string, schema *ast.Schem
 	}
 
 	return filteredSelectionSet
-
 }
 
 func includeFragment(responseObjectTypeName string, schema *ast.Schema, objectDefinition *ast.Definition, typeCondition string) bool {

--- a/execution_test.go
+++ b/execution_test.go
@@ -156,9 +156,10 @@ func TestQueryError(t *testing.T) {
 					{Line: 2, Column: 4},
 				},
 				Extensions: map[string]interface{}{
-					"code":         "NOT_FOUND",
-					"selectionSet": `{ movie(id: "1") { id title } }`,
-					"serviceName":  "",
+					"code":          "NOT_FOUND",
+					"selectionSet":  `{ movie(id: "1") { id title } }`,
+					"selectionPath": ast.Path{ast.PathName("movie")},
+					"serviceName":   "",
 				},
 			},
 			&gqlerror.Error{
@@ -230,7 +231,6 @@ func TestFederatedQueryFragmentSpreads(t *testing.T) {
 						}
 					}
 				}`))
-
 			} else {
 				w.Write([]byte(`
 				{
@@ -251,7 +251,6 @@ func TestFederatedQueryFragmentSpreads(t *testing.T) {
 						]
 					}
 				}`))
-
 			}
 		}),
 	}
@@ -1469,7 +1468,6 @@ func TestNestingNullableBoundaryTypes(t *testing.T) {
 
 		f.checkSuccess(t)
 	})
-
 }
 
 func TestQueryExecutionWithTypename(t *testing.T) {


### PR DESCRIPTION
When federated service response contains graphql error with provided "Path" the bramble override this with it own internal "path" and we lost this information. This pull request will fix it.