### PR TITLE
Run tests without output by default

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,18 @@
+package bramble
+
+import (
+	"flag"
+	"io"
+	"os"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	if !testing.Verbose() {
+		log.SetOutput(io.Discard)
+	}
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
Since tests can create log entries on the error level etc, it can look like tests have failed when it is expected output.

By default send `logrus` output to `io.Discard` unless `-test.v` is true