### PR TITLE
Replace deprecated ioutil funcs with io

### DIFF
--- a/execution_test.go
+++ b/execution_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -2267,7 +2266,7 @@ func TestQueryExecutionMultipleObjects(t *testing.T) {
 					movies: [Movie!]
 				}`,
 				handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					body, _ := ioutil.ReadAll(r.Body)
+					body, _ := io.ReadAll(r.Body)
 					if strings.Contains(string(body), "movies") {
 						w.Write([]byte(`{
 							"data": {
@@ -2722,7 +2721,7 @@ func TestQueryExecutionWithUnions(t *testing.T) {
 					animals: [Animal]!
 				}`,
 				handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					b, _ := ioutil.ReadAll(r.Body)
+					b, _ := io.ReadAll(r.Body)
 					if strings.Contains(string(b), "animals") {
 						w.Write([]byte(`{
 							"data": {
@@ -2839,7 +2838,7 @@ func TestQueryExecutionWithNamespaces(t *testing.T) {
 					}
 				`,
 				handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					b, _ := ioutil.ReadAll(r.Body)
+					b, _ := io.ReadAll(r.Body)
 
 					if strings.Contains(string(b), "CA7") {
 						w.Write([]byte(`{

--- a/middleware.go
+++ b/middleware.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 
@@ -78,7 +77,7 @@ func monitoringMiddleware(h http.Handler) http.Handler {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-		r.Body = ioutil.NopCloser(&buf)
+		r.Body = io.NopCloser(&buf)
 
 		r = r.WithContext(ctx)
 


### PR DESCRIPTION
[`ioutil` has been deprecated](https://pkg.go.dev/io/ioutil) and equivalent methods are in the `io` package now.