### PR TITLE
Small docs updates

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -44,7 +44,7 @@ To build the `bramble` command:
 
 ```bash
 go build -o bramble ./cmd
-./bramble -conf config.json
+./bramble -config config.json
 ```
 
 To run the tests:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -49,7 +49,7 @@ bramble config.json
 ### Docker
 
 ```
-docker run -p 8082:8082 -p 8083:8083 -p 8084:8084 -v $(PWD)/config.json:/config.json ghcr.io/movio/bramble
+docker run -p 8082:8082 -v $(PWD)/config.json:/config.json ghcr.io/movio/bramble
 ```
 
 ## Querying Bramble


### PR DESCRIPTION
- `-conf` is deprecated and while still accepted `-config` is the preferred flag
- remove unnecessary and incorrect port forwards from getting started example