### PR TITLE
Remove incorrect prometheus counter reset.

### DIFF
--- a/executable_schema.go
+++ b/executable_schema.go
@@ -79,8 +79,6 @@ func (s *ExecutableSchema) UpdateSchema(forceRebuild bool) error {
 		}
 	}()
 
-	promServiceUpdateError.Reset()
-
 	for url, s := range s.Services {
 		logger := log.WithField("url", url)
 		updated, err := s.Update()


### PR DESCRIPTION
The counter being reset every single time the schema was updated caused the metric to virtually be unscrapable. Every reset throws away the existing values. If prometheus has a larger scrape interval than bramble's schema update you will lose most of the counter's data.