### PR TITLE
Add sleep in Gateway.UpdateSchema

### DIFF
--- a/gateway.go
+++ b/gateway.go
@@ -27,6 +27,7 @@ func NewGateway(executableSchema *ExecutableSchema, plugins []Plugin) *Gateway {
 
 // UpdateSchemas periodically updates the execute schema
 func (g *Gateway) UpdateSchemas(interval time.Duration) {
+	time.Sleep(interval)
 	for range time.Tick(interval) {
 		err := g.ExecutableSchema.UpdateSchema(false)
 		if err != nil {


### PR DESCRIPTION
Add a `time.Sleep` call to make the initialisation of the gateway more robust. In `main()`,  `UpdateSchemas()` is called _before_ the initialisation of the private router, so plugins have no chance to respond to schema update requests on the first try.