### PR TITLE
Link Docker images on profile page

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-X 'github.com/movio/bramble.Ver
 
 FROM gcr.io/distroless/static
 
+LABEL org.opencontainers.image.source="https://github.com/movio/bramble"
+
 COPY --from=builder /workspace/bramble .
 
 EXPOSE 8082


### PR DESCRIPTION
This PR adds a label to the Docker images you provide to Github container registry, in order to get the Docker images linked on the project page on Github.

![2023-03-18 at 00 20 01@2x](https://user-images.githubusercontent.com/4409904/226068620-72cd79c2-80f9-4d01-a5bc-2da579288854.png)


Further reads:

- [Github docs regarding labeling](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#labelling-container-images)
- Actually got this hint from this [blog post](https://blog.codecentric.de/github-container-registry)