### PR TITLE
Use cache mount for build tasks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.17-alpine3.15 AS builder
 
 ARG VERSION=SNAPSHOT
 ENV GO111MODULE=on
-ENV CGO_ENABLED=0
+ENV CGO_ENABLED=0 GOOS=linux
 
 WORKDIR /workspace
 
@@ -12,7 +12,7 @@ RUN go mod download
 
 COPY . /workspace/
 
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-X 'github.com/movio/bramble.Version=$VERSION'" -o bramble ./cmd/bramble
+RUN go build -ldflags="-X 'github.com/movio/bramble.Version=$VERSION'" -o bramble ./cmd/bramble
 
 FROM gcr.io/distroless/static
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,11 @@ WORKDIR /workspace
 
 COPY go.mod go.sum /workspace/
 
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod go mod download
 
 COPY . /workspace/
 
-RUN go build -ldflags="-X 'github.com/movio/bramble.Version=$VERSION'" -o bramble ./cmd/bramble
+RUN --mount=type=cache,target=/root/.cache/go-build go build -ldflags="-X 'github.com/movio/bramble.Version=$VERSION'" -o bramble ./cmd/bramble
 
 FROM gcr.io/distroless/static
 


### PR DESCRIPTION
This speeds up subsequent image build times when modifying the `Dockerfile`