### PR TITLE
Split error update metrics into gauge and counter

### DIFF
--- a/executable_schema.go
+++ b/executable_schema.go
@@ -83,12 +83,14 @@ func (s *ExecutableSchema) UpdateSchema(forceRebuild bool) error {
 		logger := log.WithField("url", url)
 		updated, err := s.Update()
 		if err != nil {
-			promServiceUpdateError.WithLabelValues(s.ServiceURL).Inc()
+			promServiceUpdateErrorCounter.WithLabelValues(s.ServiceURL).Inc()
+			promServiceUpdateErrorGauge.WithLabelValues(s.ServiceURL).Set(1)
 			invalidSchema, forceRebuild = true, true
 			logger.WithError(err).Error("unable to update service")
 			// Ignore this service in this update
 			continue
 		}
+		promServiceUpdateErrorGauge.WithLabelValues(s.ServiceURL).Set(0)
 		logger = log.WithFields(log.Fields{
 			"version": s.Version,
 			"service": s.Name,

--- a/metrics.go
+++ b/metrics.go
@@ -15,10 +15,20 @@ var (
 		Help: "A gauge representing the current status of remote services schemas",
 	})
 
-	promServiceUpdateError = prometheus.NewCounterVec(
+	promServiceUpdateErrorCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
+			Name: "service_update_error_total",
+			Help: "A counter indicating how many times services have failed to update",
+		},
+		[]string{
+			"service",
+		},
+	)
+
+	promServiceUpdateErrorGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
 			Name: "service_update_error",
-			Help: "A counter indicating what services have failed to update",
+			Help: "A gauge indicating what services are failing to update",
 		},
 		[]string{
 			"service",
@@ -74,7 +84,8 @@ var (
 // RegisterMetrics register the prometheus metrics.
 func RegisterMetrics() {
 	prometheus.MustRegister(promInvalidSchema)
-	prometheus.MustRegister(promServiceUpdateError)
+	prometheus.MustRegister(promServiceUpdateErrorCounter)
+	prometheus.MustRegister(promServiceUpdateErrorGauge)
 	prometheus.MustRegister(promHTTPInFlightGauge)
 	prometheus.MustRegister(promHTTPRequestCounter)
 	prometheus.MustRegister(promHTTPResponseDurations)


### PR DESCRIPTION
Use counter for tracking number of failures and the gauge for current error states.

We were finding once the error state was triggered it could not be reset as the counter is intended to be used as an ever incrementing metric.