### PR TITLE
Add a plugin to allow headers passthrough

### DIFF
--- a/plugins/headers.go
+++ b/plugins/headers.go
@@ -1,0 +1,53 @@
+package plugins
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/movio/bramble"
+)
+
+func init() {
+	bramble.RegisterPlugin(&HeadersPlugin{})
+}
+
+type HeadersPlugin struct {
+	bramble.BasePlugin
+	config HeadersPluginConfig
+}
+
+type HeadersPluginConfig struct {
+	AllowedHeaders []string `json:"allowed-headers"`
+}
+
+func NewHeadersPlugin(options HeadersPluginConfig) *HeadersPlugin {
+	return &HeadersPlugin{bramble.BasePlugin{}, options}
+}
+
+func (p *HeadersPlugin) ID() string {
+	return "headers"
+}
+
+func (p *HeadersPlugin) Configure(cfg *bramble.Config, data json.RawMessage) error {
+	return json.Unmarshal(data, &p.config)
+}
+
+func (p *HeadersPlugin) middleware(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		for _, header := range p.config.AllowedHeaders {
+			if value := r.Header.Get(header); value != "" {
+				ctx = bramble.AddOutgoingRequestsHeaderToContext(ctx, header, value)
+			}
+		}
+		h.ServeHTTP(rw, r.WithContext(ctx))
+	})
+}
+
+func (p *HeadersPlugin) ApplyMiddlewarePublicMux(h http.Handler) http.Handler {
+	return p.middleware(h)
+}
+
+func (p *HeadersPlugin) ApplyMiddlewarePrivateMux(h http.Handler) http.Handler {
+	return p.middleware(h)
+}

--- a/plugins/headers_test.go
+++ b/plugins/headers_test.go
@@ -1,0 +1,41 @@
+package plugins
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/movio/bramble"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHeaders(t *testing.T) {
+	p := NewHeadersPlugin(HeadersPluginConfig{
+		AllowedHeaders: []string{"X-Fun-Header"},
+	})
+
+	t.Run("unknown header is not in context", func(t *testing.T) {
+		called := false
+		handler := p.ApplyMiddlewarePublicMux(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			headers := bramble.GetOutgoingRequestHeadersFromContext(r.Context())
+			assert.Empty(t, headers.Get("X-Bad-Header"))
+		}))
+		req := httptest.NewRequest(http.MethodPost, "/query", nil)
+		req.Header.Add("X-Bad-Header", "bad")
+		handler.ServeHTTP(httptest.NewRecorder(), req)
+		assert.True(t, called)
+	})
+	t.Run("allowed header is in context", func(t *testing.T) {
+		called := false
+		handler := p.ApplyMiddlewarePublicMux(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			headers := bramble.GetOutgoingRequestHeadersFromContext(r.Context())
+			assert.Equal(t, headers.Get("X-Fun-Header"), "funtime")
+		}))
+		req := httptest.NewRequest(http.MethodPost, "/query", nil)
+		req.Header.Add("X-Fun-Header", "funtime")
+		handler.ServeHTTP(httptest.NewRecorder(), req)
+		assert.True(t, called)
+	})
+}


### PR DESCRIPTION
Headers listed in the `allowed-headers` field of the plugin config will be passed from the client request to downstream services. This allows passing information like `Authorization` headers or custom information.

```json
{
  "plugins": [
    {
      "name": "headers",
      "config": {
        "allowed-headers": ["Authorization"],
      }
    }
  ]
}
```

Addresses #212 raised by @codedge.