### PR TITLE
Fix serialisation bug when a fragment spread was not exhaustive

### DIFF
--- a/execution_result.go
+++ b/execution_result.go
@@ -364,23 +364,21 @@ func formatResponseDataRec(schema *ast.Schema, selectionSet ast.SelectionSet, re
 	case []interface{}:
 		buf.WriteString("[")
 		for i, v := range result {
-			innerBody := formatResponseDataRec(schema, selectionSet, v, false)
-			buf.Write(innerBody)
-
-			if i < len(result)-1 {
+			if i > 0 {
 				buf.WriteString(",")
 			}
+			innerBody := formatResponseDataRec(schema, selectionSet, v, false)
+			buf.Write(innerBody)
 		}
 		buf.WriteString("]")
 	case []map[string]interface{}:
 		buf.WriteString("[")
 		for i, v := range result {
-			innerBody := formatResponseDataRec(schema, selectionSet, v, false)
-			buf.Write(innerBody)
-
-			if i < len(result)-1 {
+			if i > 0 {
 				buf.WriteString(",")
 			}
+			innerBody := formatResponseDataRec(schema, selectionSet, v, false)
+			buf.Write(innerBody)
 		}
 		buf.WriteString("]")
 	}


### PR DESCRIPTION
When a response included multiple implementations of an interface type but the query only asked for certain types in the fragment spread invalid json could be generated, as a loop around the serialisation function added in a comma but without any accompanying content.

For this example schema
```graphql
interface Gizmo {
    id: ID!
    name: String!
}

type Gadget implements Gizmo {
    id: ID!
    name: String!
    owner: String!
}

type Tool implements Gizmo {
    id: ID!
    name: String!
    category: String!
}

type Query {
    gizmos: [Gizmo!]!
}
```
The query
```graphql
query Gizmo {
    gizmos {
        id
        ...GizmoDetails
    }
}

fragment GizmoDetails on Gizmo {
    ... on Gadget {
        name
        owner
    }
}
```
would end up with invalid JSON for the `Tool` `Gizmo` as it would write a `,` after the `id` field expecting to then go through the fragment and write more values.

This changes the `formatResponseDataRec` so that it collects the next value, checks it has content and only writes a `,` if it's about to write more data after that. Changing the general logic from write a comma after everything except the last item to, writing a comma before every item after the first one.