### PR TITLE
Handle empty fragment spread being first in query

### DIFF
--- a/execution_result.go
+++ b/execution_result.go
@@ -320,7 +320,8 @@ func formatResponseDataRec(schema *ast.Schema, selectionSet ast.SelectionSet, re
 		objectTypename := extractAndCastTypenameField(result)
 		filteredSelectionSet := unionAndTrimSelectionSet(objectTypename, schema, selectionSet)
 
-		for i, selection := range filteredSelectionSet {
+		itemWritten := false
+		for _, selection := range filteredSelectionSet {
 			var innerBody []byte
 			switch selection := selection.(type) {
 			case *ast.InlineFragment:
@@ -349,10 +350,11 @@ func formatResponseDataRec(schema *ast.Schema, selectionSet ast.SelectionSet, re
 				innerBody = innerBuf.Bytes()
 			}
 			if len(innerBody) > 0 {
-				if i > 0 {
+				if itemWritten {
 					buf.WriteString(",")
 				}
 				buf.Write(innerBody)
+				itemWritten = true
 			}
 		}
 		if !insideFragment {


### PR DESCRIPTION
The previous fix only handled cases where an empty fragment returned nothing after a field had already been written, if it was first and returned nothing the subsequent fields would write an invalid comma ahead of the `innerBody`.

As discussed in #215 we need to rewrite this in a more robust way without relying on string building but this should handle the bug for now.