### PR TITLE
Use testing helpers

### DIFF
--- a/auth_test.go
+++ b/auth_test.go
@@ -660,6 +660,7 @@ func strToSelectionSet(schema *ast.Schema, query string) ast.SelectionSet {
 }
 
 func assertSelectionSetsEqual(t *testing.T, schema *ast.Schema, expected, actual ast.SelectionSet) {
+	t.Helper()
 	expectedStr := formatSelectionSet(testContextWithoutVariables(nil), schema, expected)
 	actualStr := formatSelectionSet(testContextWithoutVariables(nil), schema, actual)
 

--- a/execution_test.go
+++ b/execution_test.go
@@ -3532,6 +3532,7 @@ func jsonToInterfaceSlice(jsonString string) []interface{} {
 // jsonEqWithOrder checks that the JSON are equals, including the order of the
 // fields
 func jsonEqWithOrder(t *testing.T, expected, actual string) {
+	t.Helper()
 	d1 := json.NewDecoder(bytes.NewBufferString(expected))
 	d2 := json.NewDecoder(bytes.NewBufferString(actual))
 
@@ -3560,6 +3561,7 @@ func jsonEqWithOrder(t *testing.T, expected, actual string) {
 }
 
 func assertQueriesEqual(t *testing.T, schema, expected, actual string) bool {
+	t.Helper()
 	s := gqlparser.MustLoadSchema(&ast.Source{Input: schema})
 
 	var expectedBuf bytes.Buffer

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -7,15 +7,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// can only run one test at a time that takes over the logrus output
-var logrusLock = sync.Mutex{}
 
 func TestGatewayQuery(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -71,9 +67,6 @@ func TestGatewayQuery(t *testing.T) {
 }
 
 func TestRequestJSONBodyLogging(t *testing.T) {
-	logrusLock.Lock()
-	defer logrusLock.Unlock()
-
 	server := NewGateway(NewExecutableSchema(nil, 50, nil), nil).Router(&Config{})
 
 	body := map[string]interface{}{
@@ -103,9 +96,6 @@ func TestRequestJSONBodyLogging(t *testing.T) {
 }
 
 func TestRequestInvalidJSONBodyLogging(t *testing.T) {
-	logrusLock.Lock()
-	defer logrusLock.Unlock()
-
 	server := NewGateway(nil, nil).Router(&Config{})
 
 	body := `{ "invalid": "json`
@@ -132,9 +122,6 @@ func TestRequestInvalidJSONBodyLogging(t *testing.T) {
 }
 
 func TestRequestTextBodyLogging(t *testing.T) {
-	logrusLock.Lock()
-	defer logrusLock.Unlock()
-
 	server := NewGateway(nil, nil).Router(&Config{})
 
 	body := `the request body`

--- a/instrumentation_test.go
+++ b/instrumentation_test.go
@@ -4,12 +4,16 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"sync"
 	"testing"
 	"time"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
+
+// can only run one test at a time that takes over the logrus output
+var logrusLock = sync.Mutex{}
 
 func collectLogEvent(t *testing.T, f func()) map[string]interface{} {
 	t.Helper()
@@ -18,6 +22,8 @@ func collectLogEvent(t *testing.T, f func()) map[string]interface{} {
 	logger := log.StandardLogger()
 	prevOut := logger.Out
 	prevFmt := logger.Formatter
+	logrusLock.Lock()
+	defer logrusLock.Unlock()
 	logger.SetOutput(w)
 	logger.SetFormatter(&log.JSONFormatter{})
 	t.Cleanup(func() {

--- a/merge_fixtures_test.go
+++ b/merge_fixtures_test.go
@@ -136,6 +136,7 @@ func assertSchemaIntrospectionTypes(t *testing.T, schema *ast.Schema) {
 }
 
 func assertSchemaBuiltinDirectives(t *testing.T, schema *ast.Schema) {
+	t.Helper()
 	emptyAST := gqlparser.MustLoadSchema(&ast.Source{Name: "empty", Input: ""})
 	builtInDirectives := []string{"skip", "include", "deprecated"}
 	for _, d := range builtInDirectives {

--- a/plan_fixtures_test.go
+++ b/plan_fixtures_test.go
@@ -310,6 +310,7 @@ func (f *PlanTestFixture) Plan(t *testing.T, query string) (*QueryPlan, error) {
 }
 
 func (f *PlanTestFixture) Check(t *testing.T, query string, expectedJSON string) {
+	t.Helper()
 	plan, err := f.Plan(t, query)
 	require.NoError(t, err)
 	plan.SortSteps()
@@ -317,11 +318,13 @@ func (f *PlanTestFixture) Check(t *testing.T, query string, expectedJSON string)
 }
 
 func (f *PlanTestFixture) CheckError(t *testing.T, query string) {
+	t.Helper()
 	_, err := f.Plan(t, query)
 	require.Error(t, err)
 }
 
 func (f *PlanTestFixture) CheckUnorderedRootFieldSelections(t *testing.T, query string, expectedSelections []string) {
+	t.Helper()
 	ctx := graphql.WithOperationContext(context.Background(), &graphql.OperationContext{
 		Variables: map[string]interface{}{},
 	})

--- a/validate_test.go
+++ b/validate_test.go
@@ -9,29 +9,29 @@ import (
 )
 
 type testSchema struct {
-	t      *testing.T
+	*testing.T
 	schema *ast.Schema
 }
 
 func withSchema(t *testing.T, schema string) *testSchema {
 	t.Helper()
 	return &testSchema{
-		t:      t,
+		T:      t,
 		schema: gqlparser.MustLoadSchema(&ast.Source{Name: "fixture", Input: schema}),
 	}
 }
 
 func (t *testSchema) assertValid(f func(*ast.Schema) error) {
-	t.t.Helper()
-	assert.NoError(t.t, f(t.schema))
+	t.Helper()
+	assert.NoError(t.T, f(t.schema))
 }
 
 func (t *testSchema) assertInvalid(err string, f func(*ast.Schema) error) {
-	t.t.Helper()
+	t.Helper()
 	e := f(t.schema)
-	assert.Error(t.t, e)
+	assert.Error(t.T, e)
 	if e != nil {
-		assert.Equal(t.t, err, e.Error())
+		assert.Equal(t.T, err, e.Error())
 	}
 }
 


### PR DESCRIPTION
- Make sure `t.Helper()` is called everywhere relevant
- Use `t.Cleanup()` to remove custom teardown code
- Move a setting change that was in a strange place to closer to the test function