### PR TITLE
Add a counter metric for service timeouts

### DIFF
--- a/client.go
+++ b/client.go
@@ -9,9 +9,11 @@ import (
 	"io"
 	"math"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/vektah/gqlparser/v2/ast"
 )
 
@@ -115,6 +117,11 @@ func (c *GraphQLClient) Request(ctx context.Context, url string, request *Reques
 
 	res, err := c.HTTPClient.Do(httpReq)
 	if err != nil {
+		if os.IsTimeout(err) {
+			promServiceTimeoutErrorCounter.With(prometheus.Labels{
+				"service": url,
+			}).Inc()
+		}
 		return fmt.Errorf("error during request: %w", err)
 	}
 	defer res.Body.Close()

--- a/metrics.go
+++ b/metrics.go
@@ -25,6 +25,16 @@ var (
 		},
 	)
 
+	promServiceTimeoutErrorCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "service_timeout_error_total",
+			Help: "A counter indicating how many times services have timed out",
+		},
+		[]string{
+			"service",
+		},
+	)
+
 	promServiceUpdateErrorGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "service_update_error",
@@ -84,6 +94,7 @@ var (
 // RegisterMetrics register the prometheus metrics.
 func RegisterMetrics() {
 	prometheus.MustRegister(promInvalidSchema)
+	prometheus.MustRegister(promServiceTimeoutErrorCounter)
 	prometheus.MustRegister(promServiceUpdateErrorCounter)
 	prometheus.MustRegister(promServiceUpdateErrorGauge)
 	prometheus.MustRegister(promHTTPInFlightGauge)


### PR DESCRIPTION
This will provide a metric for knowing if downstream services are hitting the time limit (if set by the limits plugin) for a request.