### PR TITLE
Don't exit on misconfigured plugins

### DIFF
--- a/config.go
+++ b/config.go
@@ -245,9 +245,11 @@ func (c *Config) ConfigurePlugins() []Plugin {
 			log.Warnf("plugin %q not found", pl.Name)
 			continue
 		}
+
 		err := p.Configure(c, pl.Config)
 		if err != nil {
-			log.WithError(err).Fatalf("error unmarshalling config for plugin %q: %s", pl.Name, err)
+			log.WithError(err).Warnf("error unmarshalling config for plugin %q (skipping plugin)", pl.Name)
+			continue
 		}
 		enabledPlugins = append(enabledPlugins, p)
 	}


### PR DESCRIPTION
I don't think a misconfigured plugin should not prevent bramble from starting up. The handling should be analogous to the case where the plugin is unregistered, warn and move on. 