### PR TITLE
Add configuration options for net/http timeouts

### DIFF
--- a/config.go
+++ b/config.go
@@ -21,19 +21,31 @@ type PluginConfig struct {
 	Config json.RawMessage
 }
 
+type TimeoutConfig struct {
+	ReadTimeout          string        `json:"read"`
+	ReadTimeoutDuration  time.Duration `json:"-"`
+	WriteTimeout         string        `json:"write"`
+	WriteTimeoutDuration time.Duration `json:"-"`
+	IdleTimeout          string        `json:"idle"`
+	IdleTimeoutDuration  time.Duration `json:"-"`
+}
+
 // Config contains the gateway configuration
 type Config struct {
-	IdFieldName            string    `json:"id-field-name"`
-	GatewayListenAddress   string    `json:"gateway-address"`
-	DisableIntrospection   bool      `json:"disable-introspection"`
-	MetricsListenAddress   string    `json:"metrics-address"`
-	PrivateListenAddress   string    `json:"private-address"`
-	GatewayPort            int       `json:"gateway-port"`
-	MetricsPort            int       `json:"metrics-port"`
-	PrivatePort            int       `json:"private-port"`
-	Services               []string  `json:"services"`
-	LogLevel               log.Level `json:"loglevel"`
-	PollInterval           string    `json:"poll-interval"`
+	IdFieldName            string        `json:"id-field-name"`
+	GatewayListenAddress   string        `json:"gateway-address"`
+	DisableIntrospection   bool          `json:"disable-introspection"`
+	MetricsListenAddress   string        `json:"metrics-address"`
+	PrivateListenAddress   string        `json:"private-address"`
+	GatewayPort            int           `json:"gateway-port"`
+	MetricsPort            int           `json:"metrics-port"`
+	PrivatePort            int           `json:"private-port"`
+	DefaultTimeouts        TimeoutConfig `json:"default-timeouts"`
+	GatewayTimeouts        TimeoutConfig `json:"gateway-timeouts"`
+	PrivateTimeouts        TimeoutConfig `json:"private-timeouts"`
+	Services               []string      `json:"services"`
+	LogLevel               log.Level     `json:"loglevel"`
+	PollInterval           string        `json:"poll-interval"`
 	PollIntervalDuration   time.Duration
 	MaxRequestsPerQuery    int64 `json:"max-requests-per-query"`
 	MaxServiceResponseSize int64 `json:"max-service-response-size"`
@@ -116,6 +128,25 @@ func (c *Config) Load() error {
 		return fmt.Errorf("invalid poll interval: %w", err)
 	}
 
+	c.DefaultTimeouts.ReadTimeoutDuration, err = time.ParseDuration(c.DefaultTimeouts.ReadTimeout)
+	if err != nil {
+		return fmt.Errorf("invalid default read timeout: %w", err)
+	}
+	c.DefaultTimeouts.WriteTimeoutDuration, err = time.ParseDuration(c.DefaultTimeouts.WriteTimeout)
+	if err != nil {
+		return fmt.Errorf("invalid default write timeout: %w", err)
+	}
+	c.DefaultTimeouts.IdleTimeoutDuration, err = time.ParseDuration(c.DefaultTimeouts.IdleTimeout)
+	if err != nil {
+		return fmt.Errorf("invalid default idle timeout: %w", err)
+	}
+	if err = c.loadTimeouts(&c.GatewayTimeouts, "gateway", c.DefaultTimeouts); err != nil {
+		return err
+	}
+	if err = c.loadTimeouts(&c.PrivateTimeouts, "private", c.DefaultTimeouts); err != nil {
+		return err
+	}
+
 	services, err := c.buildServiceList()
 	if err != nil {
 		return err
@@ -124,6 +155,39 @@ func (c *Config) Load() error {
 
 	c.plugins = c.ConfigurePlugins()
 
+	return nil
+}
+
+func (c *Config) loadTimeouts(config *TimeoutConfig, name string, defaults TimeoutConfig) error {
+	var err error
+	if config.ReadTimeout != "" {
+		config.ReadTimeoutDuration, err = time.ParseDuration(config.ReadTimeout)
+		if err != nil {
+			return fmt.Errorf("invalid %s read timeout: %w", name, err)
+		}
+	}
+	if config.ReadTimeoutDuration == 0 {
+		config.ReadTimeoutDuration = defaults.ReadTimeoutDuration
+	}
+	if config.WriteTimeout != "" {
+		config.WriteTimeoutDuration, err = time.ParseDuration(config.WriteTimeout)
+		if err != nil {
+			return fmt.Errorf("invalid %s write timeout: %w", name, err)
+		}
+	}
+	if config.WriteTimeoutDuration == 0 {
+		fmt.Println("copying default write timeout")
+		config.WriteTimeoutDuration = defaults.WriteTimeoutDuration
+	}
+	if config.IdleTimeout != "" {
+		config.IdleTimeoutDuration, err = time.ParseDuration(config.IdleTimeout)
+		if err != nil {
+			return fmt.Errorf("invalid %s idle timeout: %w", name, err)
+		}
+	}
+	if config.IdleTimeoutDuration == 0 {
+		config.IdleTimeoutDuration = defaults.IdleTimeoutDuration
+	}
 	return nil
 }
 
@@ -219,6 +283,11 @@ func GetConfig(configFiles []string) (*Config, error) {
 	}
 
 	cfg := Config{
+		DefaultTimeouts: TimeoutConfig{
+			ReadTimeout:  "5s",
+			WriteTimeout: "10s",
+			IdleTimeout:  "120s",
+		},
 		GatewayPort:            8082,
 		PrivatePort:            8083,
 		MetricsPort:            9009,

--- a/config.json.example
+++ b/config.json.example
@@ -1,7 +1,17 @@
 {
   "services": ["http://localhost:4000/graphql"],
+  "default-timeouts": {
+    "read": "5s",
+    "idle": "120s"
+  },
   "gateway-port": 8082,
+  "gateway-timeouts": {
+    "write": "20s"
+  },
   "private-port": 8083,
+  "private-timeouts": {
+    "write": "10s"
+  },
   "metrics-port": 8084,
   "log-level": "info",
   "poll-interval": "5s",

--- a/config_test.go
+++ b/config_test.go
@@ -2,6 +2,7 @@ package bramble
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -38,4 +39,13 @@ func TestConfig(t *testing.T) {
 		cfg.PrivateListenAddress = "127.0.0.1:8084"
 		require.Equal(t, "http://127.0.0.1:8084/plugin", cfg.PrivateHttpAddress("plugin"))
 	})
+}
+
+func TestParseExampleConfig(t *testing.T) {
+	cfg, err := GetConfig([]string{"config.json.example"})
+	require.NoError(t, err)
+	require.Equal(t, 5*time.Second, cfg.DefaultTimeouts.ReadTimeoutDuration)
+	require.Equal(t, 120*time.Second, cfg.DefaultTimeouts.IdleTimeoutDuration)
+	require.Equal(t, 20*time.Second, cfg.GatewayTimeouts.WriteTimeoutDuration)
+	require.Equal(t, 10*time.Second, cfg.PrivateTimeouts.WriteTimeoutDuration)
 }

--- a/main.go
+++ b/main.go
@@ -46,20 +46,20 @@ func Main() {
 	var wg sync.WaitGroup
 	wg.Add(3)
 
-	go runHandler(ctx, &wg, "metrics", cfg.MetricAddress(), NewMetricsHandler())
-	go runHandler(ctx, &wg, "private", cfg.PrivateAddress(), gtw.PrivateRouter())
-	go runHandler(ctx, &wg, "public", cfg.GatewayAddress(), gtw.Router(cfg))
+	go runHandler(ctx, &wg, "metrics", cfg.MetricAddress(), cfg.DefaultTimeouts, NewMetricsHandler())
+	go runHandler(ctx, &wg, "private", cfg.PrivateAddress(), cfg.PrivateTimeouts, gtw.PrivateRouter())
+	go runHandler(ctx, &wg, "public", cfg.GatewayAddress(), cfg.GatewayTimeouts, gtw.Router(cfg))
 
 	wg.Wait()
 }
 
-func runHandler(ctx context.Context, wg *sync.WaitGroup, name, addr string, handler http.Handler) {
+func runHandler(ctx context.Context, wg *sync.WaitGroup, name, addr string, timeouts TimeoutConfig, handler http.Handler) {
 	srv := &http.Server{
 		Addr:         addr,
 		Handler:      handler,
-		ReadTimeout:  5 * time.Second,
-		WriteTimeout: 10 * time.Second,
-		IdleTimeout:  120 * time.Second,
+		ReadTimeout:  timeouts.ReadTimeoutDuration,
+		WriteTimeout: timeouts.WriteTimeoutDuration,
+		IdleTimeout:  timeouts.IdleTimeoutDuration,
 	}
 
 	go func() {


### PR DESCRIPTION
These timeouts should be tuneable for users who don't want to limit downstream services to only accept fast responses.

Address #228 by providing the option to increase the write timeout.

@codedge can you give this a review and see if it addresses your issue, it wasn't able to be configured by the `limits` plugin as it's the `main` method that sets up the `http.Server` instances.

In the `config.json` you can either provide a `default-timeouts` map of `read`, `write` and `idle` keys that will be used for all the `http.Server` instances or override the defaults with `gateway-timeouts` and `private-timeouts` maps that only need to provide values differing from the defaults.