### PR TITLE
Log out request ID when the plugin is enabled

### DIFF
--- a/plugins/request_id.go
+++ b/plugins/request_id.go
@@ -29,6 +29,9 @@ func (p *RequestIdentifierPlugin) middleware(h http.Handler) http.HandlerFunc {
 		}
 
 		ctx := r.Context()
+
+		bramble.AddField(ctx, "request.id", requestID)
+
 		ctx = bramble.AddOutgoingRequestsHeaderToContext(ctx, BrambleRequestHeader, requestID)
 		h.ServeHTTP(rw, r.WithContext(ctx))
 	})


### PR DESCRIPTION
Without this we can't actually correlate back to a bramble request