### PR TITLE
Format Request-ID as canonical UUID

### DIFF
--- a/plugins/request_id.go
+++ b/plugins/request_id.go
@@ -2,6 +2,7 @@ package plugins
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/gofrs/uuid"
 	"github.com/movio/bramble"
@@ -24,12 +25,13 @@ func (p *RequestIdentifierPlugin) ID() string {
 func (p *RequestIdentifierPlugin) middleware(h http.Handler) http.HandlerFunc {
 	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		requestID := r.Header.Get(BrambleRequestHeader)
-		if requestID == "" {
-			requestID = uuid.Must(uuid.NewV4()).String()
-		}
 
 		ctx := r.Context()
-
+		if strings.TrimSpace(requestID) == "" {
+			requestID = uuid.Must(uuid.NewV4()).String()
+		} else if id, err := uuid.FromString(requestID); err == nil {
+			requestID = id.String()
+		}
 		bramble.AddField(ctx, "request.id", requestID)
 
 		ctx = bramble.AddOutgoingRequestsHeaderToContext(ctx, BrambleRequestHeader, requestID)

--- a/plugins/request_id_test.go
+++ b/plugins/request_id_test.go
@@ -1,0 +1,62 @@
+package plugins
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gofrs/uuid"
+	"github.com/movio/bramble"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReqestIdHeader(t *testing.T) {
+	p := RequestIdentifierPlugin{}
+
+	t.Run("request id is added to outgoing context when not provided", func(t *testing.T) {
+		called := false
+		handler := p.ApplyMiddlewarePublicMux(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			headers := bramble.GetOutgoingRequestHeadersFromContext(r.Context())
+			reqID := headers.Get(BrambleRequestHeader)
+			assert.NotEmpty(t, reqID)
+			id, err := uuid.FromString(reqID)
+			assert.NoError(t, err)
+			assert.True(t, id.Version() == uuid.V4)
+		}))
+		req := httptest.NewRequest(http.MethodPost, "/query", nil)
+		handler.ServeHTTP(httptest.NewRecorder(), req)
+		assert.True(t, called)
+	})
+	t.Run("request id is passed to outgoing context when provided", func(t *testing.T) {
+		called := false
+		handler := p.ApplyMiddlewarePublicMux(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			headers := bramble.GetOutgoingRequestHeadersFromContext(r.Context())
+			reqID := headers.Get(BrambleRequestHeader)
+			assert.NotEmpty(t, reqID)
+			id, err := uuid.FromString(reqID)
+			assert.NoError(t, err)
+			assert.True(t, id.Version() == uuid.V4)
+		}))
+		req := httptest.NewRequest(http.MethodPost, "/query", nil)
+		req.Header.Add(BrambleRequestHeader, uuid.Must(uuid.NewV4()).String())
+		handler.ServeHTTP(httptest.NewRecorder(), req)
+		assert.True(t, called)
+	})
+	t.Run("request id is reformatted when parseable as a UUID", func(t *testing.T) {
+		called := false
+		reqID := uuid.Must(uuid.NewV4()).String()
+		handler := p.ApplyMiddlewarePublicMux(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			headers := bramble.GetOutgoingRequestHeadersFromContext(r.Context())
+			id := headers.Get(BrambleRequestHeader)
+			assert.Equal(t, reqID, id)
+		}))
+		req := httptest.NewRequest(http.MethodPost, "/query", nil)
+		req.Header.Add(BrambleRequestHeader, strings.ReplaceAll(reqID, "-", ""))
+		handler.ServeHTTP(httptest.NewRecorder(), req)
+		assert.True(t, called)
+	})
+}


### PR DESCRIPTION
If the provided request ID is a UUID, parse the value and ensure it is formatted consistently when being passed downstream and being logged.

Also added some tests for the plugin.