### PR TITLE
Use custom http clients for downstream Services

### DIFF
--- a/config.go
+++ b/config.go
@@ -331,9 +331,16 @@ func (c *Config) Init() error {
 		return fmt.Errorf("error building service list: %w", err)
 	}
 
+	serviceClientOptions := []ClientOpt{
+		WithMaxResponseSize(c.MaxServiceResponseSize),
+	}
+	if c.QueryHTTPClient != nil {
+		serviceClientOptions = append(serviceClientOptions, WithHTTPClient(c.QueryHTTPClient))
+	}
+
 	var services []*Service
 	for _, s := range c.Services {
-		services = append(services, NewService(s))
+		services = append(services, NewService(s, serviceClientOptions...))
 	}
 
 	queryClientOptions := []ClientOpt{WithMaxResponseSize(c.MaxServiceResponseSize), WithUserAgent(GenerateUserAgent("query"))}

--- a/executable_schema.go
+++ b/executable_schema.go
@@ -56,7 +56,7 @@ func (s *ExecutableSchema) UpdateServiceList(services []string) error {
 		if svc, ok := s.Services[svcURL]; ok {
 			newServices[svcURL] = svc
 		} else {
-			newServices[svcURL] = NewService(svcURL)
+			newServices[svcURL] = NewService(svcURL, WithHTTPClient(s.GraphqlClient.HTTPClient))
 		}
 	}
 	s.Services = newServices

--- a/introspection.go
+++ b/introspection.go
@@ -21,10 +21,11 @@ type Service struct {
 }
 
 // NewService returns a new Service.
-func NewService(serviceURL string) *Service {
+func NewService(serviceURL string, opts ...ClientOpt) *Service {
+	opts = append(opts, WithUserAgent(GenerateUserAgent("update")))
 	s := &Service{
 		ServiceURL: serviceURL,
-		client:     NewClientWithoutKeepAlive(WithUserAgent(GenerateUserAgent("update"))),
+		client:     NewClientWithoutKeepAlive(opts...),
 	}
 	return s
 }


### PR DESCRIPTION
We are using mTLS with custom certificates and need to override the default http transport. It looked like it was working by overwriting the `QueryHTTPClient` field on the config but noticed that it wasnt being respected when new services was instantiated.