### PR TITLE
Clean up some debug information

### DIFF
--- a/executable_schema.go
+++ b/executable_schema.go
@@ -236,7 +236,7 @@ func (s *ExecutableSchema) ExecuteQuery(ctx context.Context) *graphql.Response {
 		}
 	}
 
-	timings["execution"] = time.Since(executionStart).Round(time.Millisecond).String()
+	timings["execution"] = time.Since(executionStart).String()
 
 	mergeStart := time.Now()
 	mergedResult, err := mergeExecutionResults(results)
@@ -260,11 +260,11 @@ func (s *ExecutableSchema) ExecuteQuery(ctx context.Context) *graphql.Response {
 	}
 
 	errs = append(errs, bubbleErrs...)
-	timings["merge"] = time.Since(mergeStart).Round(time.Millisecond).String()
+	timings["merge"] = time.Since(mergeStart).String()
 
 	formattingStart := time.Now()
 	formattedResponse := formatResponseData(filteredSchema, operation.SelectionSet, mergedResult)
-	timings["format"] = time.Since(formattingStart).Round(time.Millisecond).String()
+	timings["format"] = time.Since(formattingStart).String()
 
 	if len(errs) > 0 {
 		AddField(ctx, "errors", errs)

--- a/instrumentation.go
+++ b/instrumentation.go
@@ -50,10 +50,9 @@ func (e *event) addFields(fields EventFields) {
 
 func (e *event) finish() {
 	e.writeLock.Do(func() {
-		log.WithFields(log.Fields{
-			"timestamp": e.timestamp.Format(time.RFC3339Nano),
-			"duration":  time.Since(e.timestamp).String(),
-		}).WithFields(log.Fields(e.fields)).Info(e.name)
+		log.WithField("duration", time.Since(e.timestamp).String()).
+			WithFields(log.Fields(e.fields)).
+			Info(e.name)
 	})
 }
 

--- a/instrumentation_test.go
+++ b/instrumentation_test.go
@@ -88,7 +88,7 @@ func TestEventMeasurement(t *testing.T) {
 		time.Sleep(time.Microsecond)
 	})
 
-	if ts, ok := output["timestamp"].(string); ok {
+	if ts, ok := output["time"].(string); ok {
 		timestamp, err := time.Parse(time.RFC3339Nano, ts)
 		assert.NoError(t, err)
 		assert.WithinDuration(t, start, timestamp, time.Second)


### PR DESCRIPTION
- Remove duplicated timestamp in log line
- Stop rounding the timings map in the response, most of the values were being rounded to `0s`