### PR TITLE
Use go.mod to define go version in Actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,9 +7,9 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.17
+          go-version-file: go.mod
 
       - name: Build
         run: go build -v ./cmd/bramble


### PR DESCRIPTION
Instead of specifying the go version again, as it has been testing on 1.17 even though it was updated to 1.20 at v1.4.10