### PR TITLE
Remove charset from Accept header

### DIFF
--- a/client.go
+++ b/client.go
@@ -146,7 +146,7 @@ func (c *GraphQLClient) Request(ctx context.Context, url string, request *Reques
 	}
 
 	httpReq.Header.Set("Content-Type", "application/json; charset=utf-8")
-	httpReq.Header.Set("Accept", "application/json; charset=utf-8")
+	httpReq.Header.Set("Accept", "application/json")
 
 	if c.UserAgent != "" {
 		httpReq.Header.Set("User-Agent", c.UserAgent)

--- a/client.go
+++ b/client.go
@@ -168,6 +168,10 @@ func (c *GraphQLClient) Request(ctx context.Context, url string, request *Reques
 	}
 	defer res.Body.Close()
 
+	if res.StatusCode != http.StatusOK {
+		return traceErr(fmt.Errorf("unexpected response code: %s", res.Status))
+	}
+
 	maxResponseSize := c.MaxResponseSize
 	if maxResponseSize == 0 {
 		maxResponseSize = math.MaxInt64


### PR DESCRIPTION
The npm module `graphql-http` is checking the Accept header and is looking for `utf8` in the charset instead of `utf-8`.

https://github.com/graphql/graphql-http/blob/v1.22.0/src/handler.ts#L593

JSON is almost always encoded in UTF-8 so we should be ok not specifying that.

I've raised an issue: https://github.com/graphql/graphql-http/issues/120
