### PR TITLE
Inject execution debugging info into query plan

### DIFF
--- a/plan.go
+++ b/plan.go
@@ -31,17 +31,15 @@ type executionStepResult struct {
 }
 
 func (e *executionStepResult) MarshalJSON() ([]byte, error) {
-	type toMarshal struct {
+	return json.Marshal(&struct {
 		Executed  bool
 		Error     error `json:",omitempty"`
 		TimeTaken string
-	}
-	j := toMarshal{
+	}{
 		Executed:  e.executed,
 		TimeTaken: e.timeTaken.String(),
 		Error:     e.error,
-	}
-	return json.Marshal(&j)
+	})
 }
 
 // MarshalJSON marshals the step the JSON
@@ -49,24 +47,21 @@ func (s *QueryPlanStep) MarshalJSON() ([]byte, error) {
 	ctx := graphql.WithOperationContext(context.Background(), &graphql.OperationContext{
 		Variables: map[string]interface{}{},
 	})
-	type toMarshal struct {
+	return json.Marshal(&struct {
 		ServiceURL          string
 		ParentType          string
 		SelectionSet        string
 		InsertionPoint      []string
 		ExecutionStepResult *executionStepResult `json:",omitempty"`
 		Then                []*QueryPlanStep
-	}
-	j := toMarshal{
+	}{
 		ServiceURL:          s.ServiceURL,
 		ParentType:          s.ParentType,
 		SelectionSet:        formatSelectionSetSingleLine(ctx, nil, s.SelectionSet),
 		InsertionPoint:      s.InsertionPoint,
 		Then:                s.Then,
 		ExecutionStepResult: s.executionResult,
-	}
-
-	return json.Marshal(&j)
+	})
 }
 
 // QueryPlan is a query execution plan

--- a/plan.go
+++ b/plan.go
@@ -39,12 +39,8 @@ func (e *executionStepResult) MarshalJSON() ([]byte, error) {
 	j := toMarshal{
 		Executed:  e.executed,
 		TimeTaken: e.timeTaken.String(),
+		Error:     e.error,
 	}
-
-	if e.error != nil {
-		j.Error = e.error
-	}
-
 	return json.Marshal(&j)
 }
 
@@ -62,15 +58,12 @@ func (s *QueryPlanStep) MarshalJSON() ([]byte, error) {
 		Then                []*QueryPlanStep
 	}
 	j := toMarshal{
-		ServiceURL:     s.ServiceURL,
-		ParentType:     s.ParentType,
-		SelectionSet:   formatSelectionSetSingleLine(ctx, nil, s.SelectionSet),
-		InsertionPoint: s.InsertionPoint,
-		Then:           s.Then,
-	}
-
-	if s.executionResult != nil {
-		j.ExecutionStepResult = s.executionResult
+		ServiceURL:          s.ServiceURL,
+		ParentType:          s.ParentType,
+		SelectionSet:        formatSelectionSetSingleLine(ctx, nil, s.SelectionSet),
+		InsertionPoint:      s.InsertionPoint,
+		Then:                s.Then,
+		ExecutionStepResult: s.executionResult,
 	}
 
 	return json.Marshal(&j)


### PR DESCRIPTION
As each step is completed, inject some information into the step that aids in debugging step failures and timing.

The information is accessed on the result object when the below request header is sent: `X-Bramble-Debug: plan`