### PR TITLE
Add ability to expand gateway handler for plugins

### DIFF
--- a/gateway.go
+++ b/gateway.go
@@ -53,6 +53,10 @@ func (g *Gateway) Router(cfg *Config) http.Handler {
 		gatewayHandler.Use(extension.Introspection{})
 	}
 
+	for _, plugin := range g.plugins {
+		plugin.SetupGatewayHandler(gatewayHandler)
+	}
+
 	mux.Handle("/query", applyMiddleware(otelhttp.NewHandler(gatewayHandler, "/query"), debugMiddleware))
 
 	for _, plugin := range g.plugins {

--- a/plugin.go
+++ b/plugin.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/99designs/gqlgen/graphql"
+	"github.com/99designs/gqlgen/graphql/handler"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -20,6 +21,7 @@ type Plugin interface {
 	// Init is called once on initialization
 	Init(schema *ExecutableSchema)
 	SetupPublicMux(mux *http.ServeMux)
+	SetupGatewayHandler(handler *handler.Server)
 	SetupPrivateMux(mux *http.ServeMux)
 	// Should return true and the query path if the plugin is a service that
 	// should be federated by Bramble
@@ -43,6 +45,8 @@ func (p *BasePlugin) Configure(*Config, json.RawMessage) error {
 
 // Init ...
 func (p *BasePlugin) Init(s *ExecutableSchema) {}
+
+func (p *BasePlugin) SetupGatewayHandler(handler *handler.Server) {}
 
 // SetupPublicMux ...
 func (p *BasePlugin) SetupPublicMux(mux *http.ServeMux) {}


### PR DESCRIPTION
For example, this will allow you to implement: [Disabling introspection based on authentication](https://gqlgen.com/reference/introspection/#disabling-introspection-based-on-authentication)

```go
func (p *IntrospectionPlugin) SetupGatewayHandler(handler *handler.Server) {
  handler.AroundOperations(
    func(ctx context.Context, next graphql.OperationHandler) graphql.ResponseHandler {
      if u := authentication.GetRequestUserFromCtx(ctx); u.IsAuthorized() {
        graphql.GetOperationContext(ctx).DisableIntrospection = false
      }

      return next(ctx)
    },
  )
}
```