### PR TITLE
Include operation type and name in log message

### DIFF
--- a/instrumentation_test.go
+++ b/instrumentation_test.go
@@ -54,13 +54,17 @@ func collectEventFromContext(ctx context.Context, t *testing.T, f func(*event)) 
 	})
 }
 
+func testEventName(EventFields) string {
+	return "test"
+}
+
 func TestDropsField(t *testing.T) {
 	AddField(context.TODO(), "val", "test")
 	assert.True(t, true)
 }
 
 func TestEventLogOnFinish(t *testing.T) {
-	ctx, _ := startEvent(context.TODO(), "test")
+	ctx, _ := startEvent(context.TODO(), testEventName)
 	output := collectEventFromContext(ctx, t, func(*event) {
 		AddField(ctx, "val", "test")
 	})
@@ -69,7 +73,7 @@ func TestEventLogOnFinish(t *testing.T) {
 }
 
 func TestAddMultipleToEventOnContext(t *testing.T) {
-	ctx, _ := startEvent(context.TODO(), "test")
+	ctx, _ := startEvent(context.TODO(), testEventName)
 	output := collectEventFromContext(ctx, t, func(*event) {
 		AddFields(ctx, EventFields{
 			"gizmo":   "foo",
@@ -83,7 +87,7 @@ func TestAddMultipleToEventOnContext(t *testing.T) {
 
 func TestEventMeasurement(t *testing.T) {
 	start := time.Now()
-	ctx, _ := startEvent(context.TODO(), "test")
+	ctx, _ := startEvent(context.TODO(), testEventName)
 	output := collectEventFromContext(ctx, t, func(*event) {
 		time.Sleep(time.Microsecond)
 	})


### PR DESCRIPTION
This is intended to help us differentiate requests in the logs based on the operation name. With custom filters we could use the fields on the event but automatic tools like DataDog appear to group on the `msg` key.

So a request will now log something like:
```json
{
  "duration": "11.3045ms",
  "level": "info",
  "msg": "query:randomGizmo",
  "operation.name": "randomGizmo",
  "operation.type": "query",
  "request.body": {
    "operationName": "randomGizmo",
    "query": "query randomGizmo($d: String!) {\n  a: randomGizmo {\n    id\n    delay(duration: $d)\n\t\trating\n\t\temail\n\t\tname\n  }\n  b: randomGizmo {\n    id\n    delay(duration: $d)\n\t\trating\n\t\temail\n\t\tname\n  }\n}",
    "variables": {
      "d": "5ms"
    }
  },
  "request.content-type": "application/json",
  "request.path": "/query",
  "response.size": 229,
  "response.status": 200,
  "time": "2024-10-17T01:51:36.70727097Z"
}
```