### PR TITLE
Small linting fixes

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -38,8 +38,8 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.55.2
+          version: v1.61.0
           args: --disable errcheck . plugins
           only-new-issues: true

--- a/client.go
+++ b/client.go
@@ -162,13 +162,8 @@ func (c *GraphQLClient) Request(ctx context.Context, url string, request *Reques
 			promServiceTimeoutErrorCounter.With(prometheus.Labels{
 				"service": url,
 			}).Inc()
-
-			// Return raw timeout error to allow caller to handle it since a
-			// downstream caller may want to retry, and they will have to jump
-			// through hoops to detect this error otherwise.
-			return traceErr(err)
 		}
-		return traceErr(fmt.Errorf("error during request: %w", err))
+		return traceErr(err)
 	}
 	defer res.Body.Close()
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -121,7 +121,7 @@ e.g.
 ```json
 {
   "errors": {
-    "message": "error during request: Post \"http://localhost:8080/query\": context deadline exceeded",
+    "message": "Post \"http://localhost:8080/query\": context deadline exceeded",
      "extensions": {
         "selectionSet": "{ serviceB _bramble_id: id }"
       },

--- a/executable_schema.go
+++ b/executable_schema.go
@@ -221,7 +221,7 @@ func (s *ExecutableSchema) ExecuteQuery(ctx context.Context) *graphql.Response {
 	})
 	if err != nil {
 		traceErr(err)
-		return s.interceptResponse(ctx, operation.Name, operationCtx.RawQuery, variables, graphql.ErrorResponse(ctx, err.Error()))
+		return s.interceptResponse(ctx, operation.Name, operationCtx.RawQuery, variables, graphql.ErrorResponse(ctx, "%s", err.Error()))
 	}
 
 	extensions := make(map[string]interface{})

--- a/executable_schema.go
+++ b/executable_schema.go
@@ -103,9 +103,7 @@ func (s *ExecutableSchema) UpdateSchema(ctx context.Context, forceRebuild bool) 
 	// Avoid fetching more than 64 servides in parallel,
 	// as high concurrency can actually hurt performance
 	group.SetLimit(64)
-	for url_, s_ := range s.Services {
-		url := url_
-		s := s_
+	for url, s := range s.Services {
 		group.Go(func() error {
 			logger := log.WithField("url", url)
 			updated, err := s.Update(ctx)

--- a/execution_result.go
+++ b/execution_result.go
@@ -340,7 +340,7 @@ func formatResponseDataRec(schema *ast.Schema, selectionSet ast.SelectionSet, re
 				fieldData, ok := result[field.Alias]
 				if !ok {
 					innerBuf.WriteString("null")
-				} else if field.SelectionSet != nil && len(field.SelectionSet) > 0 {
+				} else if len(field.SelectionSet) > 0 {
 					val := formatResponseDataRec(schema, field.SelectionSet, fieldData, false)
 					innerBuf.Write(val)
 				} else {


### PR DESCRIPTION
- Remove an unneeded nil check
- Remove loop var aliasing prevention now go1.22 has the [loop semantics changed](https://tip.golang.org/doc/go1.22#language)