### PR TITLE
Use encoding.TextUnmarshaler to set loglevel

### DIFF
--- a/config.go
+++ b/config.go
@@ -404,11 +404,3 @@ func (a *arrayFlags) Set(value string) error {
 	*a = append(*a, value)
 	return nil
 }
-
-type levelflag struct {
-	log.LevelVar
-}
-
-func (l *levelflag) Set(s string) error {
-	return l.UnmarshalText([]byte(s))
-}

--- a/main.go
+++ b/main.go
@@ -18,13 +18,13 @@ func Main() {
 	ctx := context.Background()
 
 	var configFiles arrayFlags
-	var level levelflag
+	level := new(log.LevelVar)
 	flag.Var(&configFiles, "config", "Config file (can appear multiple times)")
 	flag.Var(&configFiles, "conf", "deprecated, use -config instead")
-	flag.Var(&level, "loglevel", "log level: debug, info, warn, error")
+	flag.TextVar(level, "loglevel", level, "log level: debug, info, warn, error")
 	flag.Parse()
 
-	logger := log.New(log.NewJSONHandler(os.Stderr, &log.HandlerOptions{Level: &level}))
+	logger := log.New(log.NewJSONHandler(os.Stderr, &log.HandlerOptions{Level: level}))
 	log.SetDefault(logger)
 
 	cfg, err := GetConfig(configFiles)
@@ -32,7 +32,6 @@ func Main() {
 		log.With("error", err).Error("failed to load config")
 		os.Exit(1)
 	}
-	level.LevelVar.Set(cfg.LogLevel)
 	go cfg.Watch()
 
 	shutdown, err := InitTelemetry(ctx, cfg.Telemetry)


### PR DESCRIPTION
`slog.LevelVar` supports the `encoding.TextUnmarshaler` interface which `flag.TextVar` can use, instead of needing to make our own.