### PR TITLE
Only log request body in debug log level

### DIFF
--- a/instrumentation.go
+++ b/instrumentation.go
@@ -50,6 +50,10 @@ func (e *event) addFields(fields EventFields) {
 	e.fieldLock.Unlock()
 }
 
+func (e *event) debugEnabled() bool {
+	return log.Default().Enabled(context.Background(), log.LevelDebug)
+}
+
 func (e *event) finish() {
 	e.writeLock.Do(func() {
 		attrs := make([]any, 0, len(e.fields))

--- a/middleware.go
+++ b/middleware.go
@@ -83,7 +83,9 @@ func monitoringMiddleware(h http.Handler) http.Handler {
 
 		r = r.WithContext(ctx)
 
-		addRequestBody(event, r, buf)
+		if event.debugEnabled() {
+			addRequestBody(event, r, buf)
+		}
 
 		m := httpsnoop.CaptureMetrics(h, w, r)
 


### PR DESCRIPTION
Until now bramble has logged the entire body of each request. This has been useful for debugging and seeing it in operation but it has a few downsides:

- Entries can be huge
- Risk of sensitive information being leaked
- IO delay of creating large log events

This doesn't address #178 but it does alter the behaviour in a way that might alleviate log size.