### PR TITLE
Address static check issues raised in the CI

### DIFF
--- a/client.go
+++ b/client.go
@@ -44,7 +44,7 @@ func NewClient(opts ...ClientOpt) *GraphQLClient {
 }
 
 func NewClientWithPlugins(plugins []Plugin, opts ...ClientOpt) *GraphQLClient {
-	var transport http.RoundTripper = http.DefaultTransport
+	transport := http.DefaultTransport
 	transport = otelhttp.NewTransport(transport)
 
 	c := &GraphQLClient{
@@ -67,7 +67,7 @@ func NewClientWithPlugins(plugins []Plugin, opts ...ClientOpt) *GraphQLClient {
 }
 
 func NewClientWithoutKeepAlive(opts ...ClientOpt) *GraphQLClient {
-	var defaultTransport = http.DefaultTransport.(*http.Transport).Clone()
+	defaultTransport := http.DefaultTransport.(*http.Transport).Clone()
 	defaultTransport.DisableKeepAlives = true
 
 	var transport http.RoundTripper = defaultTransport
@@ -144,7 +144,6 @@ func (c *GraphQLClient) Request(ctx context.Context, url string, request *Reques
 	buf, contentType, err := request.requestBody()
 	if err != nil {
 		return traceErr(fmt.Errorf("unable to encode request body: %w", err))
-
 	}
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, &buf)
 	if err != nil {
@@ -241,7 +240,6 @@ func (r *Request) WithOperationType(operation string) *Request {
 }
 
 func (r *Request) WithOperationName(operationName string) *Request {
-
 	r.OperationName = operationName
 	return r
 }

--- a/execution.go
+++ b/execution.go
@@ -561,9 +561,9 @@ func eliminateUnwantedFragments(responseObjectTypeName string, schema *ast.Schem
 }
 
 func includeFragment(responseObjectTypeName string, schema *ast.Schema, objectDefinition *ast.Definition, typeCondition string) bool {
-	return !(objectDefinition.IsAbstractType() &&
-		fragmentImplementsAbstractType(schema, objectDefinition.Name, typeCondition) &&
-		objectTypenameMatchesDifferentFragment(responseObjectTypeName, typeCondition))
+	return !objectDefinition.IsAbstractType() ||
+		!fragmentImplementsAbstractType(schema, objectDefinition.Name, typeCondition) ||
+		!objectTypenameMatchesDifferentFragment(responseObjectTypeName, typeCondition)
 }
 
 func fragmentImplementsAbstractType(schema *ast.Schema, abstractObjectTypename, fragmentTypeDefinition string) bool {

--- a/execution_test.go
+++ b/execution_test.go
@@ -857,7 +857,6 @@ func TestQueryExecutionServiceTimeout(t *testing.T) {
 			assert.Equal(t, f.errors[i].Locations, resp.Errors[i].Locations, "error locations did not match")
 			assert.Equal(t, f.errors[i].Extensions, resp.Errors[i].Extensions, "error extensions did not match")
 		}
-
 	})
 }
 
@@ -1766,9 +1765,9 @@ func TestQueryExecutionMultipleServicesWithArray(t *testing.T) {
 									"title": "title %s"
 								}`, i, id, id, id)
 						}
-						w.Write([]byte(fmt.Sprintf(`{ "data": { %s } }`, res)))
+						_, _ = fmt.Fprintf(w, `{ "data": { %s } }`, res)
 					} else {
-						w.Write([]byte(fmt.Sprintf(`{
+						_, _ = fmt.Fprintf(w, `{
 							"data": {
 								"movie": {
 									"_bramble_id": "%s",
@@ -1777,7 +1776,7 @@ func TestQueryExecutionMultipleServicesWithArray(t *testing.T) {
 									"title": "title %s"
 								}
 							}
-						}`, ids[0], ids[0], ids[0])))
+						}`, ids[0], ids[0], ids[0])
 					}
 				}),
 			},
@@ -1971,9 +1970,9 @@ func TestQueryExecutionMultipleServicesWithNestedArrays(t *testing.T) {
 									"title": "title %s"
 								}`, i, id, id, id)
 					}
-					w.Write([]byte(fmt.Sprintf(`{ "data": { %s } }`, res)))
+					_, _ = fmt.Fprintf(w, `{ "data": { %s } }`, res)
 				} else {
-					w.Write([]byte(fmt.Sprintf(`{
+					_, _ = fmt.Fprintf(w, `{
 							"data": {
 								"movie": {
 									"_bramble_id": "%s",
@@ -1982,7 +1981,7 @@ func TestQueryExecutionMultipleServicesWithNestedArrays(t *testing.T) {
 									"title": "title %s"
 								}
 							}
-						}`, ids[0], ids[0], ids[0])))
+						}`, ids[0], ids[0], ids[0])
 				}
 			}),
 		},
@@ -3446,7 +3445,7 @@ func TestSchemaUpdate_serviceError(t *testing.T) {
 			{
 				schema: schemaB,
 				handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					w.Write([]byte(fmt.Sprintf(`{
+					fmt.Fprintf(w, `{
 						"data": {
 							"service": {
 								"name": "serviceB",
@@ -3455,7 +3454,7 @@ func TestSchemaUpdate_serviceError(t *testing.T) {
 							}
 						}
 					}
-					`, schemaB)))
+					`, schemaB)
 				}),
 			},
 		},

--- a/middleware.go
+++ b/middleware.go
@@ -122,8 +122,8 @@ func addRequestBody(e *event, r *http.Request, buf bytes.Buffer) {
 	e.addField("request.content-type", contentType)
 
 	if r.Method != http.MethodHead && r.Method != http.MethodGet {
-		switch {
-		case contentType == "application/json":
+		switch contentType {
+		case "application/json":
 			var payload interface{}
 			if err := json.Unmarshal(buf.Bytes(), &payload); err == nil {
 				e.addField("request.body", &payload)
@@ -131,7 +131,7 @@ func addRequestBody(e *event, r *http.Request, buf bytes.Buffer) {
 				e.addField("request.body", buf.String())
 				e.addField("request.error", err)
 			}
-		case contentType == "multipart/form-data":
+		case "multipart/form-data":
 			e.addField("request.body", fmt.Sprintf("%d bytes", len(buf.Bytes())))
 		default:
 			e.addField("request.body", buf.String())


### PR DESCRIPTION
This PR fixes several static checks raised by the CI linter.
Example errors can be found [here](https://github.com/movio/bramble/actions/runs/24421441250/job/71344451463#step:4:110)

- Remove explicit types on variable definition
- Use DeMorgan law to make logic cleaner and easier to reason about
- Use fmt.Fprintf instead of writer
- Correct use of switch