### PR TITLE
Use SpanKindClient for graphql request spans

### DIFF
--- a/client.go
+++ b/client.go
@@ -121,7 +121,7 @@ func WithUserAgent(userAgent string) ClientOpt {
 // Request executes a GraphQL request.
 func (c *GraphQLClient) Request(ctx context.Context, url string, request *Request, out interface{}) error {
 	ctx, span := c.tracer.Start(ctx, "GraphQL Request",
-		trace.WithSpanKind(trace.SpanKindInternal),
+		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
 			semconv.GraphqlOperationTypeKey.String(string(request.OperationType)),
 			semconv.GraphqlOperationName(request.OperationName),


### PR DESCRIPTION
[AB#423832](https://dev.azure.com/vista-group/0f78e7dd-7fc6-459f-9832-a685e13cba06/_workitems/edit/423832)

When investigating some of our internal observability we would notice that even though we had correct Trace/Span propagation some spans would appear disjointed from others when they shouldn't have been

It looks like we were using the wrong Span Kind for GraphQL client requests so DD would assume that Bramble requests were internal to the service itself which wasn't quite right